### PR TITLE
﻿Fix network examples and speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,31 +89,37 @@ jobs:
         run: just wasm examples
 
       # Python SDK checks go here so we don't rebuild everything from scratch on another job
-      - name: Format check
+      # Build JS sandbox first — the Python hyperlight-js backend shares the root
+      # workspace target/ and needs hyperlight-js-runtime to be compiled.
+      - name: Build JS sandbox
+        run: just jssandbox build
+
+      - name: Python SDK Format check
         run: just python fmt-check
 
-      - name: Lint
+      - name: Python SDK Lint
         run: just python lint
 
-      - name: Build
+      - name: Python SDK Build
         run: just python build
 
-      - name: Run examples
+      - name: Python SDK examples
         run: just python examples
 
-      - name: Tests
+      - name: Python SDK Tests
         run: just python python-test
 
-      - name: Fuzz
-        run: just fuzz 90
-
-      - name: Benchmark
-        run: just benchmark
+      - name: Python SDK Fuzz
+        run: just fuzz 30
       
-      - name: Run integration examples
+      - name: Run Python SDK integration examples
         env:
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_TOKEN }}
         run: just integration-examples
+
+      # run last becuase it runs in build mode and messes with maturin
+      - name: Python SDK Benchmark
+        run: just benchmark
 
   javascript-sandbox:
     name: JS Sandbox · lint / build / examples

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,27 +55,12 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse 0.2.7",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
- "anstyle-parse 1.0.0",
+ "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -88,15 +73,6 @@ name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
 
 [[package]]
 name = "anstyle-parse"
@@ -197,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -262,16 +238,16 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -345,7 +321,7 @@ dependencies = [
  "cap-primitives 3.4.5",
  "cap-std 3.4.5",
  "io-lifetimes 2.0.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -374,7 +350,7 @@ dependencies = [
  "maybe-owned",
  "rustix 1.1.4",
  "rustix-linux-procfs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -498,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -586,7 +562,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream 1.0.0",
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -612,9 +588,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -1170,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -1180,11 +1156,11 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "anstyle",
  "env_filter",
  "jiff",
@@ -1256,7 +1232,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1336,7 +1312,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1999,6 +1975,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyperlight-sandbox-backend-hyperlight-js"
+version = "0.1.0"
+dependencies = [
+ "hyperlight-javascript-sandbox",
+ "hyperlight-sandbox",
+ "hyperlight-sandbox-pyo3-common",
+ "pyo3",
+]
+
+[[package]]
+name = "hyperlight-sandbox-backend-wasm"
+version = "0.1.0"
+dependencies = [
+ "hyperlight-sandbox",
+ "hyperlight-sandbox-pyo3-common",
+ "hyperlight-wasm-sandbox",
+ "pyo3",
+]
+
+[[package]]
+name = "hyperlight-sandbox-pyo3-common"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "hyperlight-sandbox",
+ "log",
+ "pyo3",
+ "serde_json",
+]
+
+[[package]]
 name = "hyperlight-wasm"
 version = "0.13.1"
 source = "git+https://github.com/jsturtevant/hyperlight-wasm?rev=09b5e8297d827518847c08c8506bf83e85eb89b1#09b5e8297d827518847c08c8506bf83e85eb89b1"
@@ -2243,7 +2250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes 2.0.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2276,9 +2283,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -2347,7 +2354,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -2356,9 +2363,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -2372,10 +2401,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "797146bb2677299a1eb6b7b50a890f4c361b29ef967addf5b2fa45dae1bb6d7d"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2468,9 +2499,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -2603,9 +2634,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -2790,9 +2821,9 @@ dependencies = [
 
 [[package]]
 name = "papaya"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92dd0b07c53a0a0c764db2ace8c541dc47320dad97c2200c2a637ab9dd2328f"
+checksum = "997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7"
 dependencies = [
  "equivalent",
  "seize",
@@ -3048,6 +3079,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a210c0386ef0ddedb337ec99b91e560ae9c341415ef75958cb39ddb537bb0c84"
 dependencies = [
  "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
+dependencies = [
+ "libc",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
+dependencies = [
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d671734e9d7a43449f8480f8b38115df67bef8d21f76837fa75ee7aaa5e52e"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22faaa1ce6c430a1f71658760497291065e6450d7b5dc2bcf254d49f66ee700a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -3516,9 +3605,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3539,7 +3628,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3589,7 +3678,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -3630,7 +3719,7 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -3656,9 +3745,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4034,7 +4123,7 @@ dependencies = [
  "fd-lock",
  "io-lifetimes 2.0.4",
  "rustix 0.38.44",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -4206,18 +4295,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.5+spec-1.1.0"
+version = "0.25.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
+checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -4227,9 +4316,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
  "winnow",
 ]
@@ -4349,9 +4438,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -4397,9 +4486,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -4500,9 +4589,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "7dc0882f7b5bb01ae8c5215a1230832694481c1a4be062fd410e12ea3da5b631"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4513,23 +4602,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "19280959e2844181895ef62f065c63e0ca07ece4771b53d89bfdb967d97cbf05"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "75973d3066e01d035dbedaad2864c398df42f8dd7b1ea057c35b8407c015b537"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4537,9 +4622,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "91af5e4be765819e0bcfee7322c14374dc821e35e72fa663a830bbc7dc199eac"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4550,9 +4635,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "c9bf0406a78f02f336bf1e451799cca198e8acde4ffa278f0fb20487b150a633"
 dependencies = [
  "unicode-ident",
 ]
@@ -5137,9 +5222,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "749466a37ee189057f54748b200186b59a03417a117267baf3fd89cecc9fb837"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5394,6 +5479,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -5616,9 +5710,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -5630,7 +5724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5799,18 +5893,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ members = [
 	"src/hyperlight_sandbox",
 	"src/javascript_sandbox",
 	"src/wasm_sandbox",
+	"src/sdk/python/pyo3_common",
+	"src/sdk/python/wasm_backend",
+	"src/sdk/python/hyperlight_js_backend",
 ]
 # nanvix_sandbox requires nightly Rust (nanvix uses #![feature(never_type)])
 exclude = [

--- a/examples/Justfile
+++ b/examples/Justfile
@@ -2,10 +2,10 @@ repo-root := invocation_directory()
 wit-world := if os() == "windows" { "$env:WIT_WORLD=\"" + repo-root + "/src/wasm_sandbox/wit/sandbox-world.wasm\";" } else { "WIT_WORLD=" + repo-root + "/src/wasm_sandbox/wit/sandbox-world.wasm" }
 
 integration-copilot-sdk-deps:
-    uv sync --group copilot-sdk
+    uv sync --group copilot-sdk --inexact --no-install-package hyperlight-sandbox-backend-wasm --no-install-package hyperlight-sandbox-backend-hyperlight-js
 
 integration-agent-framework-deps:
-    uv sync --group agent-framework
+    uv sync --group agent-framework --inexact --no-install-package hyperlight-sandbox-backend-wasm --no-install-package hyperlight-sandbox-backend-hyperlight-js
 
 integration-agent-framework-devui-deps:
     uv sync --group agent-framework-devui

--- a/src/hyperlight_sandbox/tests/http_integration.rs
+++ b/src/hyperlight_sandbox/tests/http_integration.rs
@@ -118,3 +118,24 @@ fn chunked_body_streams_correctly() {
     }
     .block_on();
 }
+
+#[test]
+fn send_https_get_request() {
+    async {
+        let req = HttpRequest {
+            url: url::Url::parse("https://httpbin.org/get").unwrap(),
+            method: "GET".to_string(),
+            headers: vec![],
+            body: HttpRequest::body_from_bytes(None),
+        };
+
+        let resp = http::send_http_request(req)
+            .await
+            .expect("HTTPS GET to httpbin.org failed — TLS or DNS issue");
+        assert_eq!(resp.status, 200);
+
+        let echo: serde_json::Value = serde_json::from_slice(&resp.body).unwrap();
+        assert!(echo["url"].as_str().unwrap().contains("httpbin.org"));
+    }
+    .block_on();
+}

--- a/src/javascript_sandbox/examples/network_demo.rs
+++ b/src/javascript_sandbox/examples/network_demo.rs
@@ -25,59 +25,68 @@ fn main() {
     let result = sandbox
         .run(
             r#"
-try {
-    const resp = await fetch('https://notallowed.example');
-    console.log('Got response: ' + resp.status);
-} catch (e) {
-    console.log('Network blocked: ' + e.message);
+const resp = await fetch('https://notallowed.example');
+if (resp.status === 403) {
+    console.log('Network blocked: status ' + resp.status);
     console.log('  (notallowed.example is not in the allowlist — correct!)');
+} else {
+    console.log('Got response: ' + resp.status);
 }
 "#,
         )
         .expect("test 1 failed");
     print!("{}", result.stdout);
+    assert!(
+        result.stdout.contains("Network blocked"),
+        "test 1: expected network access to be blocked"
+    );
 
     separator("Test 2: Network access to allowed domain");
     let result = sandbox
         .run(
             r#"
-const resp = await fetch('https://httpbin.org/get');
+const resp = await fetch('https://httpbin.org/json', { headers: { 'accept': 'application/json' } });
 const body = await resp.text();
 console.log('HTTP status: ' + resp.status);
-console.log('Response body (first 200 chars):');
-console.log(body.slice(0, 200));
+console.log(body);
 "#,
         )
         .expect("test 2 failed");
     print!("{}", result.stdout);
-    if result.exit_code == 0 {
-        println!("Network access to allowed domain works!");
-    } else {
-        eprintln!("Network access failed");
-        eprintln!("stderr: {}", &result.stderr[..result.stderr.len().min(300)]);
-    }
+    assert_eq!(
+        result.exit_code,
+        0,
+        "test 2: network access to allowed domain failed\nstderr: {}",
+        &result.stderr[..result.stderr.len().min(300)]
+    );
 
     separator("Test 3: Method filtering — GET allowed, POST blocked");
     let result = sandbox
         .run(
             r#"
-try {
-    const resp = await fetch('https://httpbin.org/get');
-    console.log('GET allowed: status ' + resp.status);
-} catch (e) {
-    console.log('GET result: ' + e.message);
+const getResp = await fetch('https://httpbin.org/get');
+if (getResp.status === 200) {
+    const body = await getResp.text();
+    console.log('GET allowed: status ' + getResp.status);
+    console.log(body);
+} else {
+    console.log('GET failed: status ' + getResp.status);
 }
-try {
-    const resp = await fetch('https://httpbin.org/post', { method: 'POST' });
-    console.log('POST allowed: status ' + resp.status);
-} catch (e) {
-    console.log('POST blocked: ' + e.message);
+const postResp = await fetch('https://httpbin.org/post', { method: 'POST' });
+if (postResp.status === 403) {
+    console.log('POST blocked: status ' + postResp.status);
     console.log('  (httpbin.org only allows GET — correct!)');
+} else {
+    console.log('POST allowed: status ' + postResp.status);
 }
 "#,
         )
         .expect("test 3 failed");
     print!("{}", result.stdout);
+    assert!(
+        result.stdout.contains("POST blocked"),
+        "test 3: expected POST to be blocked"
+    );
 
     separator("All tests passed!");
 }

--- a/src/javascript_sandbox/src/lib.rs
+++ b/src/javascript_sandbox/src/lib.rs
@@ -86,9 +86,11 @@ Object.defineProperty(globalThis, "fetch", { value: function(url, init = {}) {
     });
 }, writable: false, configurable: false });
 
-function handler(event) {
+async function handler(event) {
     try {
-        (0, eval)(event);
+        const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
+        const fn_ = new AsyncFunction(event);
+        await fn_();
         return { stderr: "", exit_code: 0 };
     } catch (error) {
         const msg = __stringify(error && error.stack ? error.stack : error);
@@ -304,13 +306,18 @@ impl JsGuestSandbox {
 
                     {
                         let Ok(network) = http_state.network.lock() else {
-                            return json_error("network mutex poisoned");
+                            return json_response(serde_json::json!({
+                                "status": 500,
+                                "headers": {},
+                                "body": "network mutex poisoned",
+                            }));
                         };
                         if !network.is_allowed(&parsed_url, &method) {
-                            return json_error(format!(
-                                "HTTP request denied for {} {}",
-                                method, parsed_url
-                            ));
+                            return json_response(serde_json::json!({
+                                "status": 403,
+                                "headers": {},
+                                "body": format!("HTTP request denied for {} {}", method, parsed_url),
+                            }));
                         }
                     }
 
@@ -329,7 +336,13 @@ impl JsGuestSandbox {
 
                     let resp = match sandbox_http::send_http_request(http_req).block_on() {
                         Ok(r) => r,
-                        Err(error) => return json_error(error),
+                        Err(error) => {
+                            return json_response(serde_json::json!({
+                                "status": 502,
+                                "headers": {},
+                                "body": format!("{error}"),
+                            }));
+                        }
                     };
 
                     let body = match String::from_utf8(resp.body) {

--- a/src/nanvix_sandbox/Cargo.lock
+++ b/src/nanvix_sandbox/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.25.1"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
 dependencies = [
  "gimli",
 ]
@@ -535,46 +535,48 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.127.4"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6abf69c884fde2d9d4cc232a585fb18f16af3ae04c634315c84ebe158ded92d"
+checksum = "4f248321c6a7d4de5dcf2939368e96a397ad3f53b6a076e38d0104d1da326d37"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.127.4"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "263d31fcdf83a10267e8c38b53bc8f7688dfbc331267fd8fdf5b22e0dc47a55b"
+checksum = "ab6d78ff1f7d9bf8b7e1afbedbf78ba49e38e9da479d4c8a2db094e22f64e2bc"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.127.4"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d459d5377c01c4472b71029caa2df41afaf47711676aa9b12d7414f15104637b"
+checksum = "6b6005ba640213a5b95382aeaf6b82bf028309581c8d7349778d66f27dc1180b"
 dependencies = [
  "cranelift-entity",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.127.4"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8283088d5823ba7856ab8d531b7c3654b24984748f9fd99dcf3210701fd1d065"
+checksum = "81fb5b134a12b559ff0c0f5af0fcd755ad380723b5016c4e0d36f74d39485340"
 dependencies = [
  "serde",
  "serde_derive",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.127.4"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3138316d8dd341d725d6ab1598750545c76ad32892837fde558edd68a01b43"
+checksum = "85837de8be7f17a4034a6b08816f05a3144345d2091937b39d415990daca28f4"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -586,7 +588,8 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
+ "libm",
  "log",
  "pulley-interpreter",
  "regalloc2",
@@ -594,14 +597,14 @@ dependencies = [
  "serde",
  "smallvec",
  "target-lexicon",
- "wasmtime-internal-math",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.127.4"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505cead19304a8dc8689e31b29038775c3f73f9d5ea7a5e33864437a1f46c6b6"
+checksum = "e433faa87d38e5b8ff469e44a26fea4f93e58abd7a7c10bad9810056139700c9"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -612,35 +615,36 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.127.4"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce62ba94f570644ce7de6ed05bd39ca28936665dec10a2a1f6f2c531d6add45c"
+checksum = "5397ba61976e13944ca71230775db13ee1cb62849701ed35b753f4761ed0a9b7"
 
 [[package]]
 name = "cranelift-control"
-version = "0.127.4"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6cfe339689c3926412a7060ab00ef3b2b43d936b537e7a3f696121be9d0eaa"
+checksum = "cc81c88765580720eb30f4fc2c1bfdb75fcbf3094f87b3cd69cecca79d77a245"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.127.4"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625518090e912bdfe3c41464bf97ae421f6044d4ca0f5c3267dcacdb352b033d"
+checksum = "463feed5d46cf8763f3ba3045284cf706dd161496e20ec9c14afbb4ba09b9e66"
 dependencies = [
  "cranelift-bitset",
  "serde",
  "serde_derive",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.127.4"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f652d40ddf3afb55be64d8979d312b52b384a8cebbcde1dd1c2e32ebcd4466"
+checksum = "a4c5eca7696c1c04ab4c7ed8d18eadbb47d6cc9f14ec86fe0881bf1d7e97e261"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -650,15 +654,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.127.4"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f512767e83015f4baf6e732cabca93cea82907e3ab237f826ef64f7ece75eb6"
+checksum = "f1153844610cc9c6da8cf10ce205e45da1a585b7688ed558aa808bbe2e4e6d77"
 
 [[package]]
 name = "cranelift-native"
-version = "0.127.4"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1ca6e4dca568ff988d367e4707be2362cee9782265b0a501eaf467ffd550a8"
+checksum = "a97b583fe9a60f06b0464cee6be5a17f623fd91b217aaac99b51b339d19911af"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -667,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.127.4"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97400ad8fbd3a434092fc0b486fa7784150b53187941d818b1087f3ac0a547f0"
+checksum = "8594dc6bb4860fa8292f1814c76459dbfb933e1978d8222de6380efce45c7cee"
 
 [[package]]
 name = "crc32fast"
@@ -819,12 +823,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,6 +879,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1021,11 +1025,12 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.32.3"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+checksum = "19e16c5073773ccf057c282be832a59ee53ef5ff98db3aeff7f8314f52ffc196"
 dependencies = [
- "fallible-iterator",
+ "fnv",
+ "hashbrown 0.16.1",
  "indexmap",
  "stable_deref_trait",
 ]
@@ -1085,8 +1090,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
- "serde",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1094,6 +1098,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "heck"
@@ -1318,6 +1327,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "log",
  "serde",
  "serde_json",
  "tempfile",
@@ -1933,12 +1943,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.37.3"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
 dependencies = [
  "crc32fast",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "indexmap",
  "memchr",
 ]
@@ -2090,21 +2100,21 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "40.0.4"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de307c194cf6310d486dd5595ffc329c53b4acafd54e214752c1eb2e68be3a9"
+checksum = "7975f0975fa2c047bf47d617bdf716689e42ee82b159bd000ead7330d7697a1b"
 dependencies = [
  "cranelift-bitset",
  "log",
  "pulley-macros",
- "wasmtime-internal-math",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "pulley-macros"
-version = "40.0.4"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99dca2747e910d10bafe911e172a1b35860268421c3ee5ddb7e16c35e0288b4a"
+checksum = "a210c0386ef0ddedb337ec99b91e560ae9c341415ef75958cb39ddb537bb0c84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2269,9 +2279,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.13.5"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08effbc1fa53aaebff69521a5c05640523fab037b34a4a2c109506bc938246fa"
+checksum = "952ddbfc6f9f64d006c3efd8c9851a6ba2f2b944ba94730db255d55006e0ffda"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -3418,22 +3428,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.243.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55db9c896d70bd9fa535ce83cd4e1f2ec3726b0edd2142079f594fc3be1cb35"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.243.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.245.1",
 ]
 
 [[package]]
@@ -3450,19 +3460,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.243.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d8db401b0528ec316dfbe579e6ab4152d61739cfe076706d2009127970159d"
-dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
@@ -3474,32 +3471,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmprinter"
-version = "0.243.0"
+name = "wasmparser"
+version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2b6035559e146114c29a909a3232928ee488d6507a1504d8934e8607b36d7b"
+checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41517a3716fbb8ccf46daa9c1325f760fcbff5168e75c7392288e410b91ac8"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.243.0",
+ "wasmparser 0.245.1",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "40.0.4"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0702b64d4c3fe43ae4ce229e06af06a27783e48c519e68586d180717cdd24314"
+checksum = "54fa9f298901a64ed3eae16b130f0b30c80dbb74a9e7f129a791f4e74649b917"
 dependencies = [
  "addr2line",
- "anyhow",
  "async-trait",
  "bitflags 2.11.0",
  "bumpalo",
  "cc",
  "cfg-if",
  "encoding_rs",
- "hashbrown 0.15.5",
- "indexmap",
  "libc",
  "log",
  "mach2",
@@ -3514,16 +3521,15 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.243.0",
+ "wasmparser 0.245.1",
  "wasmtime-environ",
  "wasmtime-internal-component-macro",
  "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
  "wasmtime-internal-fiber",
  "wasmtime-internal-jit-debug",
  "wasmtime-internal-jit-icache-coherence",
- "wasmtime-internal-math",
- "wasmtime-internal-slab",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
  "wasmtime-internal-winch",
@@ -3532,14 +3538,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "40.0.4"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffeb777a21965a85e4b1ce7b308c63ba130df91912096b49b95523bf3bdd2c7"
+checksum = "75a3aaaa3a522f443af67a7ed8d4efa20b0c3784e1031980537fbfcb497f70a7"
 dependencies = [
  "anyhow",
+ "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-entity",
  "gimli",
+ "hashbrown 0.16.1",
  "indexmap",
  "log",
  "object",
@@ -3547,19 +3555,21 @@ dependencies = [
  "semver",
  "serde",
  "serde_derive",
+ "sha2",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.243.0",
- "wasmparser 0.243.0",
+ "wasm-encoder 0.245.1",
+ "wasmparser 0.245.1",
  "wasmprinter",
  "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "40.0.4"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "935bb8db1e2829bf26b80ed3daeed6cf9fc804f7002c90a8d17dbd5e93c69e0b"
+checksum = "3e0d00d29ed90a63d2445072860a8a42d7151390157236a69bc3ae056786e9c9"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -3567,22 +3577,32 @@ dependencies = [
  "syn",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.243.0",
+ "wit-parser 0.245.1",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "40.0.4"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52625d0c8fe2df1d7dd96d45d37dae8818c183c183a82b2368e3741ee5253859"
+checksum = "7acfd639ca7ab9e1cc37f053edd95bed6a7bed16370a8b2643dc7d9ef3047935"
+
+[[package]]
+name = "wasmtime-internal-core"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e671917bb6856ae360cb59d7aaf26f1cfd042c7b924319dd06fd380739fc0b2e"
+dependencies = [
+ "hashbrown 0.16.1",
+ "libm",
+ "serde",
+]
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "40.0.4"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85da1ba5fee01a3ee21c4d0c8052cc9035388639fa091a969b534d4c6f8449d4"
+checksum = "f2dfd752e1dcf79eeeadc6f2681e2fb4a9f0b5534d18c5b9b93faccd0de2c80c"
 dependencies = [
- "anyhow",
  "cfg-if",
  "cranelift-codegen",
  "cranelift-control",
@@ -3597,33 +3617,33 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.243.0",
+ "wasmparser 0.245.1",
  "wasmtime-environ",
- "wasmtime-internal-math",
+ "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "40.0.4"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c7de5a0872764c1ca640886af10a70cf7f8526386906245b43cdb345ece0e6"
+checksum = "d1e9171af643316c11d6ebe52f31f6e2a5d6d1d270de9167a7b7b6f0e3f72982"
 dependencies = [
- "anyhow",
  "cc",
  "cfg-if",
  "libc",
  "rustix 1.1.4",
+ "wasmtime-environ",
  "wasmtime-internal-versioned-export-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "40.0.4"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "160acd973d770d62bef1b2697d7fac83a8fe63ef966215e624382b2a9532bd58"
+checksum = "1fe23134536b9883ffc2afcffae23f7ffbcb1791e2d9fac6d6464a37ea4c8fdd"
 dependencies = [
  "cc",
  "wasmtime-internal-versioned-export-macros",
@@ -3631,49 +3651,34 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "40.0.4"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc57f590ba7ea967ea9e8c8560175c6926e5b15d11c29bbde3ad0013a29470eb"
+checksum = "9b3112806515fac8495883885eb8dbdde849988ae91fe6beb544c0d7c0f4c9aa"
 dependencies = [
- "anyhow",
  "cfg-if",
  "libc",
+ "wasmtime-internal-core",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "wasmtime-internal-math"
-version = "40.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07612904518d47b677e8db67ca47c16d8c8cefb0099020729f886776950cb58b"
-dependencies = [
- "libm",
-]
-
-[[package]]
-name = "wasmtime-internal-slab"
-version = "40.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc83ff16531e1e1537e0de2b630af56a0a9e1fab864130c5b7e213da71783a0f"
-
-[[package]]
 name = "wasmtime-internal-unwinder"
-version = "40.0.4"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47371d697244785e4bbb371229f9a2daa8628d1e03368ec895cf658370e1bf38"
+checksum = "dafc29c6e538273fda8409335137654751bdf24beab65702b7866b0a85ee108a"
 dependencies = [
- "anyhow",
  "cfg-if",
  "cranelift-codegen",
  "log",
  "object",
+ "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "40.0.4"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad3cd4aff8f2e7ec658c7a0424b74ad88a6940505303fb0616323592a1c400a6"
+checksum = "772f2b105b7fdd3dfb2cdf70c297baaeb96fe76a95cdc6fa516f713f04090c73"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3682,17 +3687,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "40.0.4"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4d1e6a37b397aa0a16b3b7f3a48f317d73c81ac7801be1fa9a135f30c55421"
+checksum = "d556c3b176aba3cce565b2bafcdc049e7410ac1d86bf1ef663a035d9ded0dddc"
 dependencies = [
- "anyhow",
  "cranelift-codegen",
  "gimli",
  "log",
  "object",
  "target-lexicon",
- "wasmparser 0.243.0",
+ "wasmparser 0.245.1",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "winch-codegen",
@@ -3700,24 +3704,23 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "40.0.4"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73a5774737acccdc70ff27bbe9e09c45b156bd7792bb83906735a572ce122247"
+checksum = "c47507f09e68462a0ed9f351ef410584a52e01d7ec92bc588bf7fa597ce528ef"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
  "heck",
  "indexmap",
- "wit-parser 0.243.0",
+ "wit-parser 0.245.1",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "40.0.4"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5c825ed750834739f6c09d2e94746d9029e69db754a575a813c90877555f775"
+checksum = "cf7fc1eb83dd0d5a368c78d2bad2660f69c03e3c07ce2dd6d1e50fc2b9ff14db"
 dependencies = [
- "anyhow",
  "async-trait",
  "bitflags 2.11.0",
  "bytes",
@@ -3743,11 +3746,10 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "40.0.4"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caba3d794a6f6614b96ab045637852012c0df4df6ebb4ce517e8802e8cdf8776"
+checksum = "2922113f8766db31dbd93ed58ff8c056a35ac8246738c373ad37e6577140c62d"
 dependencies = [
- "anyhow",
  "async-trait",
  "bytes",
  "futures",
@@ -3767,14 +3769,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "40.0.4"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27bd98085eaa9bd0591b45709f7b3e5d9ca4962eb4b6dcf7b7a10d791a0e0495"
+checksum = "315fd7192148233c2c61753b5e8e2456e0ff96dd649f079148977554139ea4dc"
 dependencies = [
- "anyhow",
  "async-trait",
  "bytes",
  "futures",
+ "tracing",
  "wasmtime",
 ]
 
@@ -3858,11 +3860,10 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "40.0.4"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcca3ffe030cc6fe77f2055c19d850bcb2c2589fa6ddc7a8ebb446f7c2b1e715"
+checksum = "1ca3d76763e4ddc48ede73792d067396ba5ee74c3c581db90e6638fe6b46bf52"
 dependencies = [
- "anyhow",
  "cranelift-assembler-x64",
  "cranelift-codegen",
  "gimli",
@@ -3870,10 +3871,10 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.243.0",
+ "wasmparser 0.245.1",
  "wasmtime-environ",
+ "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
- "wasmtime-internal-math",
 ]
 
 [[package]]
@@ -4310,24 +4311,6 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.243.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df983a8608e513d8997f435bb74207bf0933d0e49ca97aa9d8a6157164b9b7fc"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.243.0",
-]
-
-[[package]]
-name = "wit-parser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
@@ -4342,6 +4325,25 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330698718e82983499419494dd1e3d7811a457a9bf9f69734e8c5f07a2547929"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.16.1",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.245.1",
 ]
 
 [[package]]

--- a/src/nanvix_sandbox/src/lib.rs
+++ b/src/nanvix_sandbox/src/lib.rs
@@ -13,7 +13,6 @@
 //! - stdout capture from the guest console log
 
 use std::io::Write;
-use std::path::Path;
 
 use anyhow::{Context, Result};
 use hyperlight_nanvix::{RuntimeConfig, Sandbox as NanvixSandboxInner, WorkloadType};

--- a/src/sdk/python/Justfile
+++ b/src/sdk/python/Justfile
@@ -17,26 +17,33 @@ python-sync-guest-resources:
     cp {{repo-root}}/src/wasm_sandbox/guests/javascript/js-sandbox.aot {{repo-root}}/src/sdk/python/wasm_guests/javascript_guest/javascript_guest/resources/js-sandbox.aot
     cp {{repo-root}}/src/wasm_sandbox/guests/javascript/js-sandbox.wasm {{repo-root}}/src/sdk/python/wasm_guests/javascript_guest/javascript_guest/resources/js-sandbox.wasm
 
+# Sync the venv (installs maturin, guest packages, etc.) but skip the
+# two maturin backend crates — they are built below via `maturin develop`.
+python-sync-env:
+    uv sync --frozen --inexact --no-install-package hyperlight-sandbox-backend-wasm --no-install-package hyperlight-sandbox-backend-hyperlight-js
+
 python-install-backend-wasm:
-    cd {{repo-root}}/src/sdk/python/wasm_backend && {{ wit-world }} uv run maturin develop
+    cd {{repo-root}}/src/sdk/python/wasm_backend && {{ wit-world }} uv run --no-sync maturin develop
 
 python-install-backend-wasm-release:
-    # Remove cached build-script output for hyperlight-wasm so that the
-    # wasm-runtime guest binary is rebuilt for the release profile.
-    # Without this, cargo may reuse a stale debug-mode cache entry and
-    # skip building the release binary (upstream missing rerun-if-env-changed=PROFILE).
-    rm -rf {{repo-root}}/src/sdk/python/wasm_backend/target/release/build/hyperlight-wasm-*
-    cd {{repo-root}}/src/sdk/python/wasm_backend && {{ wit-world }} uv run maturin develop --release
+    # Remove cached build-script output so the runtime binary is rebuilt
+    # for the release profile. The debug build may have left stale
+    # fingerprints that prevent the build script from re-running.
+    rm -rf {{repo-root}}/target/release/build/hyperlight-wasm-* \
+           {{repo-root}}/target/release/.fingerprint/hyperlight-wasm-*
+    cd {{repo-root}}/src/sdk/python/wasm_backend && {{ wit-world }} uv run --no-sync maturin develop --release
 
 python-install-backend-hyperlight-js:
-    cd {{repo-root}}/src/sdk/python/hyperlight_js_backend && uv run maturin develop
+    cd {{repo-root}}/src/sdk/python/hyperlight_js_backend && uv run --no-sync maturin develop
 
 python-install-backend-hyperlight-js-release:
-    cd {{repo-root}}/src/sdk/python/hyperlight_js_backend && uv run maturin develop --release
+    rm -rf {{repo-root}}/target/release/build/hyperlight-js-* \
+           {{repo-root}}/target/release/.fingerprint/hyperlight-js-*
+    cd {{repo-root}}/src/sdk/python/hyperlight_js_backend && uv run --no-sync maturin develop --release
 
-python-build: python-sync-guest-resources python-install-backend-wasm python-install-backend-hyperlight-js
+python-build: python-sync-guest-resources python-sync-env python-install-backend-wasm python-install-backend-hyperlight-js
 
-python-build-release: python-sync-guest-resources python-install-backend-wasm-release python-install-backend-hyperlight-js-release
+python-build-release: python-sync-guest-resources python-sync-env python-install-backend-wasm-release python-install-backend-hyperlight-js-release
 
 build: python-build
 

--- a/src/sdk/python/core/examples/javascript_network_demo.py
+++ b/src/sdk/python/core/examples/javascript_network_demo.py
@@ -22,15 +22,16 @@ print("═" * 60)
 print("Test 1: Network access denied without permissions")
 print("═" * 60)
 result = sandbox.run("""
-try {
-    const resp = await fetch('https://notallowed.example');
-    console.log('Got response: ' + resp.status);
-} catch (e) {
-    console.log('Network blocked: ' + e.message);
+const resp = await fetch('https://notallowed.example');
+if (resp.status === 403) {
+    console.log('Network blocked: status ' + resp.status);
     console.log('  (notallowed.example is not in the allowlist — correct!)');
+} else {
+    console.log('Got response: ' + resp.status);
 }
 """)
 print(result.stdout)
+assert "Network blocked" in result.stdout, "test 1: expected network access to be blocked"
 
 # ═══════════════════════════════════════════════════════════════════
 # Test 2: Network access — allowed domain
@@ -47,11 +48,7 @@ console.log('Response body (first 200 chars):');
 console.log(body.slice(0, 200));
 """)
 print(result.stdout)
-if result.success:
-    print("✅ Network access to allowed domain works!")
-else:
-    print("⚠️ Network access failed")
-    print(f"stderr: {result.stderr[:300]}")
+assert result.success, f"test 2: network access to allowed domain failed\nstderr: {result.stderr[:300]}"
 
 # ═══════════════════════════════════════════════════════════════════
 # Test 3: Method filtering — GET allowed, POST blocked
@@ -61,21 +58,24 @@ print("═" * 60)
 print("Test 3: Method filtering — GET allowed, POST blocked")
 print("═" * 60)
 result = sandbox.run("""
-try {
-    const resp = await fetch('https://httpbin.org/get');
-    console.log('GET allowed: status ' + resp.status);
-} catch (e) {
-    console.log('GET result: ' + e.message);
+const getResp = await fetch('https://httpbin.org/get');
+if (getResp.status === 200) {
+    const body = await getResp.text();
+    console.log('GET allowed: status ' + getResp.status);
+    console.log(body);
+} else {
+    console.log('GET failed: status ' + getResp.status);
 }
-try {
-    const resp = await fetch('https://httpbin.org/post', { method: 'POST' });
-    console.log('POST allowed: status ' + resp.status);
-} catch (e) {
-    console.log('POST blocked: ' + e.message);
-    console.log('  (httpbin.org only allows GET \u2014 correct!)');
+const postResp = await fetch('https://httpbin.org/post', { method: 'POST' });
+if (postResp.status === 403) {
+    console.log('POST blocked: status ' + postResp.status);
+    console.log('  (httpbin.org only allows GET — correct!)');
+} else {
+    console.log('POST allowed: status ' + postResp.status);
 }
 """)
 print(result.stdout)
+assert "POST blocked" in result.stdout, "test 3: expected POST to be blocked"
 
 print("═" * 60)
 print("✅ All tests passed!")

--- a/src/sdk/python/core/examples/jswasm_network_demo.py
+++ b/src/sdk/python/core/examples/jswasm_network_demo.py
@@ -28,6 +28,7 @@ try {
 }
 """)
 print(result.stdout)
+assert "Network blocked" in result.stdout, "test 1: expected network access to be blocked"
 
 # ═══════════════════════════════════════════════════════════════════
 # Test 2: Network access to allowed domain (WASI-HTTP)
@@ -44,11 +45,7 @@ console.log('Response body (first 200 chars):');
 console.log(body.slice(0, 200));
 """)
 print(result.stdout)
-if result.success:
-    print("✅ Network access to allowed domain works via WASI-HTTP!")
-else:
-    print("⚠️ Network access failed")
-    print(f"stderr: {result.stderr[:300]}")
+assert result.success, f"test 2: network access to allowed domain failed\nstderr: {result.stderr[:300]}"
 
 # ═══════════════════════════════════════════════════════════════════
 # Test 3: Method filtering — GET allowed, POST blocked
@@ -73,6 +70,7 @@ try {
 }
 """)
 print(result.stdout)
+assert "POST blocked" in result.stdout, "test 3: expected POST to be blocked"
 
 print("═" * 60)
 print("✅ All tests passed!")

--- a/src/sdk/python/core/examples/python_network_demo.py
+++ b/src/sdk/python/core/examples/python_network_demo.py
@@ -27,8 +27,7 @@ except Exception as e:
     print("  (notallowed.example is not in the allowlist — correct!)")
 """)
 print(result.stdout)
-if not result.success:
-    print("(Network access correctly denied — sandbox terminated)")
+assert "Network blocked" in result.stdout, "test 1: expected network access to be blocked"
 
 # ═══════════════════════════════════════════════════════════════════
 # Test 2: Network access to allowed domain (WASI-HTTP)
@@ -44,11 +43,7 @@ print(f"Response body (first 200 chars):")
 print(resp['body'][:200])
 """)
 print(result.stdout)
-if result.success:
-    print("✅ Network access to allowed domain works via WASI-HTTP!")
-else:
-    print("⚠️ Network access failed")
-    print(f"stderr: {result.stderr[:300]}")
+assert result.success, f"test 2: network access to allowed domain failed\nstderr: {result.stderr[:300]}"
 
 # ═══════════════════════════════════════════════════════════════════
 # Test 3: Method filtering — GET allowed, POST blocked
@@ -72,6 +67,7 @@ except Exception as e:
     print("  (httpbin.org only allows GET \u2014 correct!)")
 """)
 print(result.stdout)
+assert "POST blocked" in result.stdout, "test 3: expected POST to be blocked"
 
 print("═" * 60)
 print("✅ All tests passed!")

--- a/src/sdk/python/hyperlight_js_backend/Cargo.toml
+++ b/src/sdk/python/hyperlight_js_backend/Cargo.toml
@@ -5,10 +5,8 @@ edition = "2024"
 description = "HyperlightJS backend bindings for hyperlight-sandbox"
 license = "Apache-2.0"
 
-[workspace]
-
 [lib]
-name = "_native"
+name = "_native_js"
 crate-type = ["cdylib"]
 
 [dependencies]

--- a/src/sdk/python/hyperlight_js_backend/hyperlight_sandbox_backend_hyperlight_js/__init__.py
+++ b/src/sdk/python/hyperlight_js_backend/hyperlight_sandbox_backend_hyperlight_js/__init__.py
@@ -1,6 +1,6 @@
 """HyperlightJS backend implementation package for hyperlight_sandbox."""
 
-from hyperlight_sandbox_backend_hyperlight_js._native import (
+from hyperlight_sandbox_backend_hyperlight_js._native_js import (
     JSSandbox,
     PyExecutionResult,
     PySnapshot,

--- a/src/sdk/python/hyperlight_js_backend/pyproject.toml
+++ b/src/sdk/python/hyperlight_js_backend/pyproject.toml
@@ -21,4 +21,4 @@ classifiers = [
 [tool.maturin]
 python-source = "."
 features = ["pyo3/extension-module"]
-module-name = "hyperlight_sandbox_backend_hyperlight_js._native"
+module-name = "hyperlight_sandbox_backend_hyperlight_js._native_js"

--- a/src/sdk/python/hyperlight_js_backend/src/lib.rs
+++ b/src/sdk/python/hyperlight_js_backend/src/lib.rs
@@ -1,14 +1,12 @@
 use std::collections::HashMap;
 
-use pyo3::exceptions::PyRuntimeError;
-use pyo3::prelude::*;
-
 use hyperlight_javascript_sandbox::HyperlightJs;
-use hyperlight_sandbox::{DirPerms, FilePerms, Sandbox, SandboxConfig, HttpMethod};
-
+use hyperlight_sandbox::{DirPerms, FilePerms, HttpMethod, Sandbox, SandboxConfig};
 use hyperlight_sandbox_pyo3_common::{
     PyExecutionResult, PySnapshot, build_tool_registry, parse_size, parse_tool_registration,
 };
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
 
 #[pyclass(unsendable)]
 pub struct JSSandbox {
@@ -86,16 +84,22 @@ impl JSSandbox {
                 builder = builder.input_dir(dir);
             }
             if let Some(ref dir) = self.output_dir {
-                builder = builder.output_dir(dir, DirPerms::READ | DirPerms::MUTATE, FilePerms::READ | FilePerms::WRITE);
+                builder = builder.output_dir(
+                    dir,
+                    DirPerms::READ | DirPerms::MUTATE,
+                    FilePerms::READ | FilePerms::WRITE,
+                );
             } else if self.temp_output {
                 builder = builder.temp_output();
             }
-            let mut sandbox = builder.build()
+            let mut sandbox = builder
+                .build()
                 .map_err(|e| PyRuntimeError::new_err(format!("Failed to create sandbox: {e:#}")))?;
             for (target, methods) in std::mem::take(&mut self.pending_networks) {
                 let methods = HttpMethod::parse_list(methods)
                     .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
-                sandbox.allow_domain(&target, methods)
+                sandbox
+                    .allow_domain(&target, methods)
                     .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
             }
             self.inner = Some(sandbox);
@@ -116,7 +120,8 @@ impl JSSandbox {
         if let Some(sandbox) = self.inner.as_mut() {
             let methods = HttpMethod::parse_list(methods)
                 .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
-            sandbox.allow_domain(target, methods)
+            sandbox
+                .allow_domain(target, methods)
                 .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
         } else {
             self.pending_networks.push((target.to_string(), methods));
@@ -125,39 +130,51 @@ impl JSSandbox {
     }
 
     fn snapshot(&mut self) -> PyResult<PySnapshot> {
-        let sandbox = self.inner.as_mut()
+        let sandbox = self
+            .inner
+            .as_mut()
             .ok_or_else(|| PyRuntimeError::new_err("Sandbox not initialized"))?;
-        let snap = sandbox.snapshot()
+        let snap = sandbox
+            .snapshot()
             .map_err(|e| PyRuntimeError::new_err(format!("Snapshot failed: {e}")))?;
         Ok(PySnapshot { inner: snap })
     }
 
     fn restore(&mut self, snapshot: &PySnapshot) -> PyResult<()> {
-        let sandbox = self.inner.as_mut()
+        let sandbox = self
+            .inner
+            .as_mut()
             .ok_or_else(|| PyRuntimeError::new_err("Sandbox not initialized"))?;
-        sandbox.restore(&snapshot.inner)
+        sandbox
+            .restore(&snapshot.inner)
             .map_err(|e| PyRuntimeError::new_err(format!("Restore failed: {e}")))?;
         Ok(())
     }
 
     fn get_output_files(&self) -> PyResult<Vec<String>> {
-        let sandbox = self.inner.as_ref()
+        let sandbox = self
+            .inner
+            .as_ref()
             .ok_or_else(|| PyRuntimeError::new_err("Sandbox not initialized"))?;
-        sandbox.get_output_files()
+        sandbox
+            .get_output_files()
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to get output files: {e}")))
     }
 
     fn output_path(&self) -> PyResult<Option<String>> {
-        let sandbox = self.inner.as_ref()
+        let sandbox = self
+            .inner
+            .as_ref()
             .ok_or_else(|| PyRuntimeError::new_err("Sandbox not initialized"))?;
-        let path = sandbox.output_path()
+        let path = sandbox
+            .output_path()
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to get output path: {e}")))?;
         Ok(path.map(|p| p.display().to_string()))
     }
 }
 
 #[pymodule]
-fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn _native_js(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<JSSandbox>()?;
     m.add_class::<PyExecutionResult>()?;
     m.add_class::<PySnapshot>()?;

--- a/src/sdk/python/pyo3_common/Cargo.toml
+++ b/src/sdk/python/pyo3_common/Cargo.toml
@@ -5,8 +5,6 @@ edition = "2024"
 description = "Shared PyO3 helpers for hyperlight-sandbox backend crates"
 license = "Apache-2.0"
 
-[workspace]
-
 [dependencies]
 pyo3 = { version = "0.28", features = ["extension-module"] }
 hyperlight-sandbox = { path = "../../../hyperlight_sandbox" }

--- a/src/sdk/python/pyo3_common/src/lib.rs
+++ b/src/sdk/python/pyo3_common/src/lib.rs
@@ -1,8 +1,7 @@
+use hyperlight_sandbox::{ArgType, Snapshot, ToolRegistry, ToolSchema};
 use pyo3::exceptions::{PyRuntimeError, PyTypeError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyModule};
-
-use hyperlight_sandbox::{ArgType, Snapshot, ToolRegistry, ToolSchema};
 
 /// Convert a human-readable size string (e.g. `"200Mi"`) to bytes.
 pub fn parse_size(size: &str) -> PyResult<u64> {

--- a/src/sdk/python/wasm_backend/Cargo.toml
+++ b/src/sdk/python/wasm_backend/Cargo.toml
@@ -5,10 +5,8 @@ edition = "2024"
 description = "Wasm backend bindings for hyperlight-sandbox"
 license = "Apache-2.0"
 
-[workspace]
-
 [lib]
-name = "_native"
+name = "_native_wasm"
 crate-type = ["cdylib"]
 
 [dependencies]
@@ -16,13 +14,3 @@ pyo3 = { version = "0.28", features = ["extension-module"] }
 hyperlight-sandbox = { path = "../../../hyperlight_sandbox" }
 hyperlight-wasm-sandbox = { path = "../../../wasm_sandbox" }
 hyperlight-sandbox-pyo3-common = { path = "../pyo3_common" }
-
-[patch."https://github.com/hyperlight-dev/hyperlight"]
-hyperlight-common = { version = "=0.13.1" }
-hyperlight-guest = { version = "=0.13.1" }
-hyperlight-guest-bin = { version = "=0.13.1" }
-hyperlight-host = { version = "=0.13.1" }
-hyperlight-component-util = { git = "https://github.com/jsturtevant/hyperlight-1", branch = "wasm-component-fixes", package = "hyperlight-component-util" }
-
-[patch.crates-io]
-hyperlight-component-util = { git = "https://github.com/jsturtevant/hyperlight-1", branch = "wasm-component-fixes", package = "hyperlight-component-util" }

--- a/src/sdk/python/wasm_backend/hyperlight_sandbox_backend_wasm/__init__.py
+++ b/src/sdk/python/wasm_backend/hyperlight_sandbox_backend_wasm/__init__.py
@@ -1,6 +1,6 @@
 """Wasm backend implementation package for hyperlight_sandbox."""
 
-from hyperlight_sandbox_backend_wasm._native import (
+from hyperlight_sandbox_backend_wasm._native_wasm import (
     PyExecutionResult,
     PySnapshot,
     WasmSandbox,

--- a/src/sdk/python/wasm_backend/pyproject.toml
+++ b/src/sdk/python/wasm_backend/pyproject.toml
@@ -21,4 +21,4 @@ classifiers = [
 [tool.maturin]
 python-source = "."
 features = ["pyo3/extension-module"]
-module-name = "hyperlight_sandbox_backend_wasm._native"
+module-name = "hyperlight_sandbox_backend_wasm._native_wasm"

--- a/src/sdk/python/wasm_backend/src/lib.rs
+++ b/src/sdk/python/wasm_backend/src/lib.rs
@@ -1,14 +1,12 @@
 use std::collections::HashMap;
 
-use pyo3::exceptions::PyRuntimeError;
-use pyo3::prelude::*;
-
-use hyperlight_sandbox::{DirPerms, FilePerms, Sandbox, SandboxConfig, HttpMethod};
-use hyperlight_wasm_sandbox::Wasm;
-
+use hyperlight_sandbox::{DirPerms, FilePerms, HttpMethod, Sandbox, SandboxConfig};
 use hyperlight_sandbox_pyo3_common::{
     PyExecutionResult, PySnapshot, build_tool_registry, parse_size, parse_tool_registration,
 };
+use hyperlight_wasm_sandbox::Wasm;
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
 
 #[pyclass(unsendable)]
 pub struct WasmSandbox {
@@ -80,16 +78,22 @@ impl WasmSandbox {
                 builder = builder.input_dir(dir);
             }
             if let Some(ref dir) = self.output_dir {
-                builder = builder.output_dir(dir, DirPerms::READ | DirPerms::MUTATE, FilePerms::READ | FilePerms::WRITE);
+                builder = builder.output_dir(
+                    dir,
+                    DirPerms::READ | DirPerms::MUTATE,
+                    FilePerms::READ | FilePerms::WRITE,
+                );
             } else if self.temp_output {
                 builder = builder.temp_output();
             }
-            let mut sandbox = builder.build()
+            let mut sandbox = builder
+                .build()
                 .map_err(|e| PyRuntimeError::new_err(format!("Failed to create sandbox: {e:#}")))?;
             for (target, methods) in std::mem::take(&mut self.pending_networks) {
                 let methods = HttpMethod::parse_list(methods)
                     .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
-                sandbox.allow_domain(&target, methods)
+                sandbox
+                    .allow_domain(&target, methods)
                     .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
             }
             self.inner = Some(sandbox);
@@ -110,7 +114,8 @@ impl WasmSandbox {
         if let Some(sandbox) = self.inner.as_mut() {
             let methods = HttpMethod::parse_list(methods)
                 .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
-            sandbox.allow_domain(target, methods)
+            sandbox
+                .allow_domain(target, methods)
                 .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
         } else {
             self.pending_networks.push((target.to_string(), methods));
@@ -119,39 +124,51 @@ impl WasmSandbox {
     }
 
     fn snapshot(&mut self) -> PyResult<PySnapshot> {
-        let sandbox = self.inner.as_mut()
+        let sandbox = self
+            .inner
+            .as_mut()
             .ok_or_else(|| PyRuntimeError::new_err("Sandbox not initialized"))?;
-        let snap = sandbox.snapshot()
+        let snap = sandbox
+            .snapshot()
             .map_err(|e| PyRuntimeError::new_err(format!("Snapshot failed: {e}")))?;
         Ok(PySnapshot { inner: snap })
     }
 
     fn restore(&mut self, snapshot: &PySnapshot) -> PyResult<()> {
-        let sandbox = self.inner.as_mut()
+        let sandbox = self
+            .inner
+            .as_mut()
             .ok_or_else(|| PyRuntimeError::new_err("Sandbox not initialized"))?;
-        sandbox.restore(&snapshot.inner)
+        sandbox
+            .restore(&snapshot.inner)
             .map_err(|e| PyRuntimeError::new_err(format!("Restore failed: {e}")))?;
         Ok(())
     }
 
     fn get_output_files(&self) -> PyResult<Vec<String>> {
-        let sandbox = self.inner.as_ref()
+        let sandbox = self
+            .inner
+            .as_ref()
             .ok_or_else(|| PyRuntimeError::new_err("Sandbox not initialized"))?;
-        sandbox.get_output_files()
+        sandbox
+            .get_output_files()
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to get output files: {e}")))
     }
 
     fn output_path(&self) -> PyResult<Option<String>> {
-        let sandbox = self.inner.as_ref()
+        let sandbox = self
+            .inner
+            .as_ref()
             .ok_or_else(|| PyRuntimeError::new_err("Sandbox not initialized"))?;
-        let path = sandbox.output_path()
+        let path = sandbox
+            .output_path()
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to get output path: {e}")))?;
         Ok(path.map(|p| p.display().to_string()))
     }
 }
 
 #[pymodule]
-fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn _native_wasm(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<WasmSandbox>()?;
     m.add_class::<PyExecutionResult>()?;
     m.add_class::<PySnapshot>()?;

--- a/src/wasm_sandbox/examples/js_network_demo.rs
+++ b/src/wasm_sandbox/examples/js_network_demo.rs
@@ -48,6 +48,10 @@ try {
         )
         .expect("test 1 failed");
     print!("{}", result.stdout);
+    assert!(
+        result.stdout.contains("Network blocked"),
+        "test 1: expected network access to be blocked"
+    );
 
     separator("Test 2: Network access to allowed domain (WASI-HTTP)");
     let result = sandbox
@@ -62,12 +66,12 @@ console.log(body.slice(0, 200));
         )
         .expect("test 2 failed");
     print!("{}", result.stdout);
-    if result.exit_code == 0 {
-        println!("Network access to allowed domain works via WASI-HTTP!");
-    } else {
-        eprintln!("Network access failed");
-        eprintln!("stderr: {}", &result.stderr[..result.stderr.len().min(300)]);
-    }
+    assert_eq!(
+        result.exit_code,
+        0,
+        "test 2: network access to allowed domain failed\nstderr: {}",
+        &result.stderr[..result.stderr.len().min(300)]
+    );
 
     separator("Test 3: Method filtering — GET allowed, POST blocked");
     let result = sandbox
@@ -90,6 +94,10 @@ try {
         )
         .expect("test 3 failed");
     print!("{}", result.stdout);
+    assert!(
+        result.stdout.contains("POST blocked"),
+        "test 3: expected POST to be blocked"
+    );
 
     separator("All tests passed!");
 }

--- a/src/wasm_sandbox/examples/python_network_demo.rs
+++ b/src/wasm_sandbox/examples/python_network_demo.rs
@@ -47,6 +47,10 @@ except Exception as e:
         )
         .expect("test 1 failed");
     print!("{}", result.stdout);
+    assert!(
+        result.stdout.contains("Network blocked"),
+        "test 1: expected network access to be blocked"
+    );
 
     separator("Test 2: Network access to allowed domain (WASI-HTTP)");
     let result = sandbox
@@ -60,12 +64,12 @@ print(resp['body'][:200])
         )
         .expect("test 2 failed");
     print!("{}", result.stdout);
-    if result.exit_code == 0 {
-        println!("Network access to allowed domain works via WASI-HTTP!");
-    } else {
-        eprintln!("Network access failed");
-        eprintln!("stderr: {}", &result.stderr[..result.stderr.len().min(300)]);
-    }
+    assert_eq!(
+        result.exit_code,
+        0,
+        "test 2: network access to allowed domain failed\nstderr: {}",
+        &result.stderr[..result.stderr.len().min(300)]
+    );
 
     separator("Test 3: Method filtering — GET allowed, POST blocked");
     let result = sandbox
@@ -87,7 +91,10 @@ except Exception as e:
         )
         .expect("test 3 failed");
     print!("{}", result.stdout);
-    println!("  (example.com is allowed for GET only)");
+    assert!(
+        result.stdout.contains("POST blocked"),
+        "test 3: expected POST to be blocked"
+    );
 
     separator("All tests passed!");
 }

--- a/src/wasm_sandbox/src/wasi_impl/types/pollable.rs
+++ b/src/wasm_sandbox/src/wasi_impl/types/pollable.rs
@@ -60,15 +60,9 @@ impl AnyPollable {
     }
 
     pub async fn block(&mut self) {
-        // Cap iterations to prevent infinite busy-wait if a pollable never becomes ready.
-        const MAX_BLOCK_ITERATIONS: usize = 100_000;
-        for _ in 0..MAX_BLOCK_ITERATIONS {
-            if self.ready().await {
-                return;
-            }
+        while !self.ready().await {
             tokio::task::yield_now().await;
         }
-        log::warn!("pollable::block() exceeded {MAX_BLOCK_ITERATIONS} iterations; giving up");
     }
 
     pub fn poll(&mut self, cx: &mut Context<'_>) -> Poll<bool> {


### PR DESCRIPTION
﻿The network demos across all backends (WASM Python, WASM JS, HyperlightJS) were silently failing — every example printed `All tests passed!` regardless of whether the HTTP requests actually succeeded. This hid two real bugs and a CI design issue:

- The first bug was in AnyPollable::block(), which polled for HTTP responses using a tight yield_now() loop capped at 100k iterations.Real HTTPS requests take hundreds of milliseconds, but 100k yields complete in microseconds, so the guest always gave up before the response arrived. Removing the iteration cap and keeping the yield lets the loop wait as long as the request needs.

- The second bug was in the HyperlightJS sandbox's eval-based handler, which couldn't support await. The handler ran guest code through synchronous eval(), so await fetch(...) created an unresolved promise that crashed outside the try/catch. Wrapping the code in AsyncFunction makes top-level await work. Additionally, denied HTTP requests were throwing JS exceptions via json_error instead of returning proper HTTP responses — now they return 403 status codes that guest code can inspect normally.

All six network demos now have real assertions (assert!/assert_eq! in Rust, assert in Python) that will fail CI if anything regresses.
An HTTPS integration test against httpbin.org was added to cover TLS end-to-end.

On the CI side, the three Python SDK backend crates were separate Cargo workspaces with duplicate [patch] sections and isolated target/directories, causing the full dependency tree (~500 crates) to be compiled three times. Moving them into the root workspace means the second and third builds are essentially free. 
