### PR TITLE
Fix packages to support more python Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
 
       - name: Install Python
-        run: uv python install 3.12
+        run: uv python install 3.10 3.11 3.12 3.13
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
@@ -208,7 +208,9 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y clang
 
       - name: Build all Python packages
-        run: just python-dist
+        run: |
+          INTERPS="--interpreter $(uv python find 3.10) $(uv python find 3.11) $(uv python find 3.12) $(uv python find 3.13)"
+          just python-dist interpreters="$INTERPS"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -230,7 +232,7 @@ jobs:
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
 
       - name: Install Python
-        run: uv python install 3.12
+        run: uv python install 3.10 3.11 3.12 3.13
 
       - name: Install just
         run: cargo install --locked just
@@ -239,7 +241,10 @@ jobs:
         run: choco install llvm -y
 
       - name: Build backend wheels
-        run: just python-dist-backends
+        shell: pwsh
+        run: |
+          $interps = "3.10", "3.11", "3.12", "3.13" | ForEach-Object { & uv python find $_ }
+          just python-dist-backends interpreters="--interpreter $($interps -join ' ')"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -248,19 +253,20 @@ jobs:
 
   # Download merged Linux + Windows wheels and run wheelhouse smoke tests.
   python-wheelhouse-test:
-    name: Python wheelhouse test (${{ matrix.os }})
+    name: Python wheelhouse test (${{ matrix.os }}, py${{ matrix.python }})
     needs: [python-wheelhouse-build-linux, python-wheelhouse-build-windows]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
+        python: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
 
       - name: Install Python
-        run: uv python install 3.12
+        run: uv python install ${{ matrix.python }}
 
       - name: Install just
         run: cargo install --locked just
@@ -280,7 +286,7 @@ jobs:
           sudo chmod 666 /dev/kvm
 
       - name: Run wheelhouse tests
-        run: just python python-wheelhouse-test
+        run: just python python-wheelhouse-test ${{ matrix.python }}
 
   javascript-sandbox:
     name: JS Sandbox (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,8 +209,8 @@ jobs:
 
       - name: Build all Python packages
         run: |
-          INTERPS="--interpreter $(uv python find 3.10) $(uv python find 3.11) $(uv python find 3.12) $(uv python find 3.13)"
-          just python-dist interpreters="$INTERPS"
+          export INTERPRETERS="--interpreter $(uv python find 3.10) $(uv python find 3.11) $(uv python find 3.12) $(uv python find 3.13)"
+          just python-dist
 
       - uses: actions/upload-artifact@v4
         with:
@@ -244,7 +244,8 @@ jobs:
         shell: pwsh
         run: |
           $interps = "3.10", "3.11", "3.12", "3.13" | ForEach-Object { & uv python find $_ }
-          just python-dist-backends interpreters="--interpreter $($interps -join ' ')"
+          $env:INTERPRETERS = "--interpreter $($interps -join ' ')"
+          just python-dist-backends
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,8 +41,8 @@ jobs:
 
       - name: Build all Python packages
         run: |
-          INTERPS="--interpreter $(uv python find 3.10) $(uv python find 3.11) $(uv python find 3.12) $(uv python find 3.13)"
-          just python-dist interpreters="$INTERPS"
+          export INTERPRETERS="--interpreter $(uv python find 3.10) $(uv python find 3.11) $(uv python find 3.12) $(uv python find 3.13)"
+          just python-dist
 
       - uses: actions/upload-artifact@v4
         with:
@@ -77,7 +77,8 @@ jobs:
         shell: pwsh
         run: |
           $interps = "3.10", "3.11", "3.12", "3.13" | ForEach-Object { & uv python find $_ }
-          just python-dist-backends interpreters="--interpreter $($interps -join ' ')"
+          $env:INTERPRETERS = "--interpreter $($interps -join ' ')"
+          just python-dist-backends
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
 
       - name: Install Python
-        run: uv python install 3.12
+        run: uv python install 3.10 3.11 3.12 3.13
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
@@ -40,7 +40,9 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y clang
 
       - name: Build all Python packages
-        run: just python-dist
+        run: |
+          INTERPS="--interpreter $(uv python find 3.10) $(uv python find 3.11) $(uv python find 3.12) $(uv python find 3.13)"
+          just python-dist interpreters="$INTERPS"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -63,7 +65,7 @@ jobs:
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
 
       - name: Install Python
-        run: uv python install 3.12
+        run: uv python install 3.10 3.11 3.12 3.13
 
       - name: Install just
         run: cargo install --locked just
@@ -72,7 +74,10 @@ jobs:
         run: choco install llvm -y
 
       - name: Build backend wheels
-        run: just python-dist-backends
+        shell: pwsh
+        run: |
+          $interps = "3.10", "3.11", "3.12", "3.13" | ForEach-Object { & uv python find $_ }
+          just python-dist-backends interpreters="--interpreter $($interps -join ' ')"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/Justfile
+++ b/Justfile
@@ -41,12 +41,12 @@ test-rust:
 
 benchmark: python::python-sandbox-benchmark
 
-python-dist: (wasm::build "release") (js::build "release") python::python-dist
+python-dist interpreters="": (wasm::build "release") (js::build "release") (python::python-dist interpreters)
 
-python-dist-backends: wasm::_clean-stale-wasm wasm::guest-compile-wit js::_clean-stale
+python-dist-backends interpreters="": wasm::_clean-stale-wasm wasm::guest-compile-wit js::_clean-stale
     cargo build --manifest-path src/wasm_sandbox/Cargo.toml --release
     cargo build --manifest-path src/javascript_sandbox/Cargo.toml --release
-    just python python-dist-backends
+    just python python-dist-backends interpreters="{{interpreters}}"
 
 python-wheelhouse-test: python-dist python::python-wheelhouse-test
 

--- a/Justfile
+++ b/Justfile
@@ -41,12 +41,13 @@ test-rust:
 
 benchmark: python::python-sandbox-benchmark
 
-python-dist interpreters="": (wasm::build "release") (js::build "release") (python::python-dist interpreters)
+python-dist: (wasm::build "release") (js::build "release")
+    just python python-dist
 
-python-dist-backends interpreters="": wasm::_clean-stale-wasm wasm::guest-compile-wit js::_clean-stale
+python-dist-backends: wasm::_clean-stale-wasm wasm::guest-compile-wit js::_clean-stale
     cargo build --manifest-path src/wasm_sandbox/Cargo.toml --release
     cargo build --manifest-path src/javascript_sandbox/Cargo.toml --release
-    just python python-dist-backends interpreters="{{interpreters}}"
+    just python python-dist-backends
 
 python-wheelhouse-test: python-dist python::python-wheelhouse-test
 

--- a/src/sdk/python/Justfile
+++ b/src/sdk/python/Justfile
@@ -50,22 +50,22 @@ build: python-build
 
 #### DIST / PUBLISH ####
 
-python-dist: python-sync-guest-resources
+python-dist interpreters="": python-sync-guest-resources
     -{{rmrf}} {{dist-root}}
     cd {{repo-root}}/src/sdk/python/core && uv run python -m build --outdir {{core-dist}}
-    cd {{repo-root}}/src/sdk/python/wasm_backend && uv run maturin build --release --out {{wasm-wheels}}
-    cd {{repo-root}}/src/sdk/python/hyperlight_js_backend && uv run maturin build --release --out {{hyperlight-js-wheels}}
+    cd {{repo-root}}/src/sdk/python/wasm_backend && uv run maturin build --release --out {{wasm-wheels}} {{interpreters}}
+    cd {{repo-root}}/src/sdk/python/hyperlight_js_backend && uv run maturin build --release --out {{hyperlight-js-wheels}} {{interpreters}}
     cd {{repo-root}}/src/sdk/python/wasm_guests/python_guest && uv run python -m build --outdir {{python-guest-dist}}
     cd {{repo-root}}/src/sdk/python/wasm_guests/javascript_guest && uv run python -m build --outdir {{javascript-guest-dist}}
 
 # Build only the platform-specific maturin backend wheels.
 # Used by CI to produce Windows wheels without needing guest binaries.
 # Requires sandbox-world.wasm to exist (run `just wasm guest-compile-wit` first).
-python-dist-backends: python-sync-env
+python-dist-backends interpreters="": python-sync-env
     -{{rmrf}} {{wasm-wheels}}
     -{{rmrf}} {{hyperlight-js-wheels}}
-    cd {{repo-root}}/src/sdk/python/wasm_backend && uv run maturin build --release --out {{wasm-wheels}}
-    cd {{repo-root}}/src/sdk/python/hyperlight_js_backend && uv run maturin build --release --out {{hyperlight-js-wheels}}
+    cd {{repo-root}}/src/sdk/python/wasm_backend && uv run maturin build --release --out {{wasm-wheels}} {{interpreters}}
+    cd {{repo-root}}/src/sdk/python/hyperlight_js_backend && uv run maturin build --release --out {{hyperlight-js-wheels}} {{interpreters}}
 
 python-publish repository="pypi":
     uv publish {{ if repository != "pypi" { "--publish-url https://test.pypi.org/legacy/" } else { "" } }} {{wasm-wheels}}/*
@@ -77,20 +77,20 @@ python-publish repository="pypi":
 # Smoke-test the wheels in dist/pythonsdk/ by installing them into
 # isolated environments and running basic tests.
 # Requires `just python-dist` (root) to have been run first.
-python-wheelhouse-test:
-    uv run --no-project --no-index \
+python-wheelhouse-test python-version="":
+    uv run --no-project {{ if python-version != "" { "--python " + python-version } else { "" } }} --no-index \
         --find-links={{core-dist}} \
         --find-links={{wasm-wheels}} \
         --find-links={{python-guest-dist}} \
         --with "hyperlight-sandbox[wasm,python_guest]" \
         python {{repo-root}}/src/sdk/python/tests/wheelhouse_wasm_python.py
-    uv run --no-project --no-index \
+    uv run --no-project {{ if python-version != "" { "--python " + python-version } else { "" } }} --no-index \
         --find-links={{core-dist}} \
         --find-links={{wasm-wheels}} \
         --find-links={{javascript-guest-dist}} \
         --with "hyperlight-sandbox[wasm,javascript_guest]" \
         python {{repo-root}}/src/sdk/python/tests/wheelhouse_wasm_js.py
-    uv run --no-project --no-index \
+    uv run --no-project {{ if python-version != "" { "--python " + python-version } else { "" } }} --no-index \
         --find-links={{core-dist}} \
         --find-links={{hyperlight-js-wheels}} \
         --find-links={{javascript-guest-dist}} \

--- a/src/sdk/python/Justfile
+++ b/src/sdk/python/Justfile
@@ -5,6 +5,10 @@ export WIT_WORLD := repo-root + "/src/wasm_sandbox/wit/sandbox-world.wasm"
 rmrf := if os() == "windows" { "Remove-Item -Recurse -Force -ErrorAction SilentlyContinue" } else { "rm -rf" }
 mkdirp := if os() == "windows" { "New-Item -ItemType Directory -Force" } else { "mkdir -p" }
 
+# Set via env or CLI (e.g. `just interpreters="--interpreter python3.10 python3.13" python-dist`)
+# to build wheels for multiple Python versions. Defaults to empty (maturin uses active Python).
+interpreters := env("INTERPRETERS", "")
+
 dist-root := repo-root + "/dist/pythonsdk"
 core-dist := dist-root + "/core"
 wasm-wheels := dist-root + "/wasm_backend"
@@ -50,7 +54,7 @@ build: python-build
 
 #### DIST / PUBLISH ####
 
-python-dist interpreters="": python-sync-guest-resources
+python-dist: python-sync-guest-resources
     -{{rmrf}} {{dist-root}}
     cd {{repo-root}}/src/sdk/python/core && uv run python -m build --outdir {{core-dist}}
     cd {{repo-root}}/src/sdk/python/wasm_backend && uv run maturin build --release --out {{wasm-wheels}} {{interpreters}}
@@ -61,7 +65,7 @@ python-dist interpreters="": python-sync-guest-resources
 # Build only the platform-specific maturin backend wheels.
 # Used by CI to produce Windows wheels without needing guest binaries.
 # Requires sandbox-world.wasm to exist (run `just wasm guest-compile-wit` first).
-python-dist-backends interpreters="": python-sync-env
+python-dist-backends: python-sync-env
     -{{rmrf}} {{wasm-wheels}}
     -{{rmrf}} {{hyperlight-js-wheels}}
     cd {{repo-root}}/src/sdk/python/wasm_backend && uv run maturin build --release --out {{wasm-wheels}} {{interpreters}}


### PR DESCRIPTION
The published version is only working with Python 3.12, this makes sure we build the wheels for all the versions