### PR TITLE
Fix actions to use latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
           export INTERPRETERS="--interpreter $(uv python find 3.10) $(uv python find 3.11) $(uv python find 3.12) $(uv python find 3.13)"
           just python-dist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: python-wheels-linux
           path: dist/pythonsdk/
@@ -247,7 +247,7 @@ jobs:
           $env:INTERPRETERS = "--interpreter $($interps -join ' ')"
           just python-dist-backends
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: python-wheels-windows
           path: dist/pythonsdk/
@@ -272,7 +272,7 @@ jobs:
       - name: Install just
         run: cargo install --locked just
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: dist/pythonsdk/
           merge-multiple: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
           export INTERPRETERS="--interpreter $(uv python find 3.10) $(uv python find 3.11) $(uv python find 3.12) $(uv python find 3.13)"
           just python-dist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: python-wheels-linux
           path: dist/pythonsdk/
@@ -80,7 +80,7 @@ jobs:
           $env:INTERPRETERS = "--interpreter $($interps -join ' ')"
           just python-dist-backends
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: python-wheels-windows
           path: dist/pythonsdk/
@@ -104,7 +104,7 @@ jobs:
       - name: Install just
         run: cargo install --locked just
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: dist/pythonsdk/
           merge-multiple: true


### PR DESCRIPTION
pin to hash:

actions/download-artifact   3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  https://github.com/actions/download-artifact/releases
actions/upload-artifact bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  https://github.com/actions/upload-artifact/releases