### PR TITLE
Remove Boxing and shrink the wasm default sizes on Linux

### DIFF
--- a/docs/end-user-overview-slides.md
+++ b/docs/end-user-overview-slides.md
@@ -261,18 +261,19 @@ resp = http_get("https://other.com/admin")
 
 Measured from `benchmark.py` (release build) — 5 cold / 10 warm rounds, averages shown.
 
+==========================================================================================
 Step                                    Wasm + Python Wasm + JavaScript      HyperlightJS
 -----------------------------------------------------------------------------------------
-Cold start (create + first run)              420.8 ms          409.2 ms          386.8 ms
-Warm run (no restore)                          0.2 ms            0.4 ms            0.1 ms
-Cold start + tool dispatch                   370.7 ms          384.1 ms          387.7 ms
-Warm tool dispatch (no restore)                0.4 ms            0.4 ms            0.1 ms
-Cold start + file I/O                        451.9 ms          443.5 ms          373.7 ms
-Warm file I/O (no restore)                     0.3 ms            0.5 ms            0.1 ms
-Snapshot                                     239.6 ms          215.3 ms          168.9 ms
-Restore                                       46.7 ms           43.5 ms           41.9 ms
-Restore + run                                  2.6 ms            3.3 ms            1.5 ms
-Restore + tool dispatch                        2.7 ms            3.2 ms            1.3 ms
+Cold start (create + first run)              143.9 ms          119.9 ms           96.7 ms
+Warm run (no restore)                          0.2 ms            0.3 ms            0.1 ms
+Cold start + tool dispatch                   138.1 ms          114.5 ms          105.4 ms
+Warm tool dispatch (no restore)                0.4 ms            0.3 ms            0.1 ms
+Cold start + file I/O                        125.7 ms          119.4 ms          101.8 ms
+Warm file I/O (no restore)                     0.3 ms            0.4 ms            0.1 ms
+Snapshot                                      59.1 ms           59.7 ms           20.5 ms
+Restore                                       11.4 ms           11.1 ms           11.5 ms
+Restore + run                                  1.5 ms            1.3 ms            0.7 ms
+Restore + tool dispatch                        1.3 ms            1.2 ms            0.6 ms
 
 
 ---

--- a/src/hyperlight_sandbox/src/lib.rs
+++ b/src/hyperlight_sandbox/src/lib.rs
@@ -10,7 +10,6 @@ pub mod runtime;
 pub mod test_utils;
 pub mod tools;
 
-use std::any::Any;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
@@ -30,13 +29,13 @@ pub use tools::{ArgType, ToolRegistry, ToolSchema};
 #[cfg(windows)]
 pub const DEFAULT_HEAP_SIZE: u64 = 400 * 1024 * 1024;
 #[cfg(not(windows))]
-pub const DEFAULT_HEAP_SIZE: u64 = 200 * 1024 * 1024;
+pub const DEFAULT_HEAP_SIZE: u64 = 25 * 1024 * 1024;
 
 /// Default guest stack / scratch size in bytes (platform-dependent).
 #[cfg(windows)]
 pub const DEFAULT_STACK_SIZE: u64 = 200 * 1024 * 1024;
 #[cfg(not(windows))]
-pub const DEFAULT_STACK_SIZE: u64 = 100 * 1024 * 1024;
+pub const DEFAULT_STACK_SIZE: u64 = 35 * 1024 * 1024;
 
 /// Configuration for building a sandbox guest.
 #[derive(Debug, Clone)]
@@ -75,42 +74,31 @@ pub struct ExecutionResult {
 // Snapshot
 // ---------------------------------------------------------------------------
 
-#[derive(Clone)]
-pub struct Snapshot {
+pub struct Snapshot<T> {
     kind: &'static str,
-    runtime: std::sync::Arc<dyn Any + Send + Sync>,
+    snapshot: std::sync::Arc<T>,
 }
 
-impl Snapshot {
+impl<T> Clone for Snapshot<T> {
+    fn clone(&self) -> Self {
+        Self {
+            kind: self.kind,
+            snapshot: self.snapshot.clone(),
+        }
+    }
+}
+
+impl<T> Snapshot<T> {
     pub fn kind(&self) -> &'static str {
         self.kind
     }
 
-    pub fn new<T>(kind: &'static str, runtime: std::sync::Arc<T>) -> Self
-    where
-        T: Any + Send + Sync + 'static,
-    {
-        Self { kind, runtime }
+    pub fn new(kind: &'static str, snapshot: std::sync::Arc<T>) -> Self {
+        Self { kind, snapshot }
     }
 
-    pub fn restore<T>(
-        &self,
-        restore_runtime: impl FnOnce(std::sync::Arc<T>) -> Result<()>,
-        fs: &std::sync::Arc<std::sync::Mutex<CapFs>>,
-    ) -> Result<()>
-    where
-        T: Any + Send + Sync + 'static,
-    {
-        let runtime = self
-            .runtime
-            .clone()
-            .downcast::<T>()
-            .map_err(|_| anyhow::anyhow!("snapshot type mismatch (kind: {})", self.kind))?;
-        restore_runtime(runtime)?;
-        fs.lock()
-            .map_err(|_| anyhow::anyhow!("filesystem mutex poisoned during snapshot restore"))?
-            .clear_output_files();
-        Ok(())
+    pub fn snapshot(&self) -> &std::sync::Arc<T> {
+        &self.snapshot
     }
 }
 
@@ -119,40 +107,42 @@ impl Snapshot {
 // ---------------------------------------------------------------------------
 
 pub trait Guest: Sized {
+    type Sandbox: GuestSandbox;
     fn build(
         self,
         config: SandboxConfig,
         tools: ToolRegistry,
         network: std::sync::Arc<std::sync::Mutex<NetworkPermissions>>,
         fs: std::sync::Arc<std::sync::Mutex<CapFs>>,
-    ) -> Result<Box<dyn GuestSandbox>>;
+    ) -> Result<Self::Sandbox>;
 }
 
 pub trait GuestSandbox: Send {
+    type SnapshotData: Send + Sync + 'static;
     /// Execute guest code.
     ///
     /// Output files under `/output` are wiped before each execution.
     /// Input files are read-only and managed by the host.
     fn run(&mut self, code: &str) -> Result<ExecutionResult>;
     /// Capture a snapshot of the guest runtime state.
-    fn snapshot(&mut self) -> Result<Snapshot>;
+    fn snapshot(&mut self) -> Result<Snapshot<Self::SnapshotData>>;
     /// Restore a previously captured guest runtime state.
-    fn restore(&mut self, snapshot: &Snapshot) -> Result<()>;
+    fn restore(&mut self, snapshot: &Snapshot<Self::SnapshotData>) -> Result<()>;
 }
 
 // ---------------------------------------------------------------------------
 // Sandbox
 // ---------------------------------------------------------------------------
 
-pub struct Sandbox {
-    inner: Box<dyn GuestSandbox>,
+pub struct Sandbox<G: Guest> {
+    inner: G::Sandbox,
     network: std::sync::Arc<std::sync::Mutex<NetworkPermissions>>,
     fs: std::sync::Arc<std::sync::Mutex<CapFs>>,
 }
 
-impl Sandbox {
+impl<G: Guest> Sandbox<G> {
     /// Create a sandbox without filesystem access.
-    pub fn new<G: Guest>(guest: G, config: SandboxConfig, tools: ToolRegistry) -> Result<Self> {
+    pub fn new(guest: G, config: SandboxConfig, tools: ToolRegistry) -> Result<Self> {
         let network = std::sync::Arc::new(std::sync::Mutex::new(NetworkPermissions::new()));
         let fs = std::sync::Arc::new(std::sync::Mutex::new(CapFs::new()));
         let inner = guest.build(config, tools, network.clone(), fs.clone())?;
@@ -160,7 +150,7 @@ impl Sandbox {
     }
 
     /// Create a sandbox with a read-only input directory.
-    pub fn with_input<G: Guest>(
+    pub fn with_input(
         guest: G,
         config: SandboxConfig,
         tools: ToolRegistry,
@@ -173,10 +163,6 @@ impl Sandbox {
         Ok(Self { inner, network, fs })
     }
 
-    pub fn builder() -> SandboxBuilder<NoGuest> {
-        SandboxBuilder::default()
-    }
-
     /// Execute guest code.
     ///
     /// Output files under `/output` are cleared before each run. Input files
@@ -185,12 +171,20 @@ impl Sandbox {
         self.inner.run(code)
     }
 
-    pub fn snapshot(&mut self) -> Result<Snapshot> {
+    pub fn snapshot(&mut self) -> Result<Snapshot<<G::Sandbox as GuestSandbox>::SnapshotData>> {
         self.inner.snapshot()
     }
 
-    pub fn restore(&mut self, snapshot: &Snapshot) -> Result<()> {
-        self.inner.restore(snapshot)
+    pub fn restore(
+        &mut self,
+        snapshot: &Snapshot<<G::Sandbox as GuestSandbox>::SnapshotData>,
+    ) -> Result<()> {
+        self.inner.restore(snapshot)?;
+        self.fs
+            .lock()
+            .map_err(|_| anyhow::anyhow!("filesystem mutex poisoned during snapshot restore"))?
+            .clear_output_files();
+        Ok(())
     }
 
     /// List filenames in the output directory (without reading contents).
@@ -231,7 +225,7 @@ pub struct NoGuest;
 /// Builder for constructing a [`Sandbox`].
 ///
 /// ```rust,ignore
-/// let sandbox = Sandbox::builder()
+/// let sandbox = SandboxBuilder::new()
 ///     .module_path("guest.aot")
 ///     .output_dir("/tmp/sandbox-out")
 ///     .guest(Wasm)
@@ -244,6 +238,12 @@ pub struct SandboxBuilder<G = NoGuest> {
     input_dir: Option<PathBuf>,
     output_dir: Option<(PathBuf, DirPerms, FilePerms)>,
     temp_output: bool,
+}
+
+impl SandboxBuilder<NoGuest> {
+    pub fn new() -> Self {
+        Self::default()
+    }
 }
 
 impl Default for SandboxBuilder<NoGuest> {
@@ -336,7 +336,7 @@ impl<G> SandboxBuilder<G>
 where
     G: Guest,
 {
-    pub fn build(self) -> Result<Sandbox> {
+    pub fn build(self) -> Result<Sandbox<G>> {
         let network = std::sync::Arc::new(std::sync::Mutex::new(NetworkPermissions::new()));
         let mut vfs = CapFs::new();
         if let Some(input_dir) = &self.input_dir {

--- a/src/javascript_sandbox/examples/basics.rs
+++ b/src/javascript_sandbox/examples/basics.rs
@@ -7,7 +7,7 @@
 //! Network tests live in network_demo.rs.
 
 use hyperlight_javascript_sandbox::HyperlightJs;
-use hyperlight_sandbox::{Sandbox, ToolRegistry};
+use hyperlight_sandbox::{SandboxBuilder, ToolRegistry};
 use serde::Deserialize;
 
 fn separator(title: &str) {
@@ -54,7 +54,7 @@ fn main() {
         Ok(serde_json::json!(val))
     });
 
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(HyperlightJs)
         .with_tools(tools)
         .build()

--- a/src/javascript_sandbox/examples/filesystem_demo.rs
+++ b/src/javascript_sandbox/examples/filesystem_demo.rs
@@ -1,7 +1,7 @@
 //! Filesystem capabilities demo for the JavaScript sandbox.
 
 use hyperlight_javascript_sandbox::HyperlightJs;
-use hyperlight_sandbox::{DirPerms, FilePerms, Sandbox};
+use hyperlight_sandbox::{DirPerms, FilePerms, SandboxBuilder};
 
 fn separator(label: &str) {
     println!("\n── {label} ──");
@@ -10,7 +10,7 @@ fn separator(label: &str) {
 fn main() {
     // ── 1: No filesystem ────────────────────────────────────────────
     separator("Test 1: No filesystem");
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(HyperlightJs)
         .build()
         .expect("failed to create sandbox");
@@ -31,7 +31,7 @@ fn main() {
     let input_tmp = tempfile::tempdir().unwrap();
     std::fs::write(input_tmp.path().join("hello.txt"), b"hello from host").unwrap();
 
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(HyperlightJs)
         .input_dir(input_tmp.path())
         .build()
@@ -50,7 +50,7 @@ fn main() {
 
     // ── 3: Temp output only ─────────────────────────────────────────
     separator("Test 3: Temp output only");
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(HyperlightJs)
         .temp_output()
         .build()
@@ -74,7 +74,7 @@ fn main() {
     let input_tmp = tempfile::tempdir().unwrap();
     std::fs::write(input_tmp.path().join("data.json"), br#"{"n": 21}"#).unwrap();
 
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(HyperlightJs)
         .input_dir(input_tmp.path())
         .temp_output()
@@ -112,7 +112,7 @@ console.log('doubled: ' + data.n * 2);
     let output_tmp = tempfile::tempdir().unwrap();
     std::fs::write(input_tmp.path().join("msg.txt"), b"shout").unwrap();
 
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(HyperlightJs)
         .input_dir(input_tmp.path())
         .output_dir(
@@ -139,7 +139,7 @@ console.log('done');
 
     // ── 6: Output wiped between runs ────────────────────────────────
     separator("Test 6: Output is ephemeral");
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(HyperlightJs)
         .temp_output()
         .build()
@@ -168,7 +168,7 @@ console.log('done');
     let input_tmp = tempfile::tempdir().unwrap();
     std::fs::write(input_tmp.path().join("readonly.txt"), b"do not modify").unwrap();
 
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(HyperlightJs)
         .input_dir(input_tmp.path())
         .build()

--- a/src/javascript_sandbox/examples/network_demo.rs
+++ b/src/javascript_sandbox/examples/network_demo.rs
@@ -1,7 +1,7 @@
 //! Network access demo for the HyperlightJS sandbox backend.
 
 use hyperlight_javascript_sandbox::HyperlightJs;
-use hyperlight_sandbox::Sandbox;
+use hyperlight_sandbox::SandboxBuilder;
 
 fn separator(title: &str) {
     println!("\n{}", "═".repeat(60));
@@ -10,7 +10,7 @@ fn separator(title: &str) {
 }
 
 fn main() {
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(HyperlightJs)
         .build()
         .expect("failed to create JS sandbox");

--- a/src/javascript_sandbox/src/lib.rs
+++ b/src/javascript_sandbox/src/lib.rs
@@ -118,19 +118,19 @@ struct RunResponse {
 pub struct HyperlightJs;
 
 impl Guest for HyperlightJs {
+    type Sandbox = JsGuestSandbox;
     fn build(
         self,
         config: SandboxConfig,
         tools: ToolRegistry,
         network: std::sync::Arc<std::sync::Mutex<NetworkPermissions>>,
         fs: std::sync::Arc<std::sync::Mutex<CapFs>>,
-    ) -> Result<Box<dyn GuestSandbox>> {
+    ) -> Result<JsGuestSandbox> {
         JsGuestSandbox::new(config, tools, network, fs)
-            .map(|sandbox| Box::new(sandbox) as Box<dyn GuestSandbox>)
     }
 }
 
-struct JsGuestSandbox {
+pub struct JsGuestSandbox {
     sandbox: LoadedJSSandbox,
     files: Arc<Mutex<CapFs>>,
     stdout: Arc<Mutex<String>>,
@@ -413,11 +413,13 @@ impl JsGuestSandbox {
 }
 
 impl GuestSandbox for JsGuestSandbox {
+    type SnapshotData = JsSnapshot;
+
     fn run(&mut self, code: &str) -> Result<ExecutionResult> {
         self.run_impl(code)
     }
 
-    fn snapshot(&mut self) -> Result<Snapshot> {
+    fn snapshot(&mut self) -> Result<Snapshot<JsSnapshot>> {
         let runtime = self
             .sandbox
             .snapshot()
@@ -425,15 +427,10 @@ impl GuestSandbox for JsGuestSandbox {
         Ok(Snapshot::new("hyperlight-js", runtime))
     }
 
-    fn restore(&mut self, snapshot: &Snapshot) -> Result<()> {
-        snapshot.restore::<JsSnapshot>(
-            |rt| {
-                self.sandbox
-                    .restore(rt)
-                    .map_err(|e| anyhow::anyhow!("restore failed: {e}"))
-            },
-            &self.files,
-        )
+    fn restore(&mut self, snapshot: &Snapshot<JsSnapshot>) -> Result<()> {
+        self.sandbox
+            .restore(snapshot.snapshot().clone())
+            .map_err(|e| anyhow::anyhow!("restore failed: {e}"))
     }
 }
 

--- a/src/nanvix_sandbox/examples/hello.rs
+++ b/src/nanvix_sandbox/examples/hello.rs
@@ -1,12 +1,12 @@
 //! Example: run JavaScript and Python code in a Nanvix microkernel sandbox.
 
 use hyperlight_nanvix_sandbox::{NanvixJavaScript, NanvixPython};
-use hyperlight_sandbox::Sandbox;
+use hyperlight_sandbox::{Sandbox, SandboxBuilder};
 
 fn main() {
     // --- JavaScript ---
     println!("=== Nanvix JavaScript Sandbox ===\n");
-    let mut js_sandbox = match Sandbox::builder()
+    let mut js_sandbox = match SandboxBuilder::new()
         .guest(NanvixJavaScript)
         .build()
     {
@@ -44,7 +44,7 @@ console.log("2 + 3 =", 2 + 3);
 
     // --- Python ---
     println!("\n=== Nanvix Python Sandbox ===\n");
-    let mut py_sandbox = match Sandbox::builder()
+    let mut py_sandbox = match SandboxBuilder::new()
         .guest(NanvixPython)
         .build()
     {

--- a/src/nanvix_sandbox/src/lib.rs
+++ b/src/nanvix_sandbox/src/lib.rs
@@ -29,14 +29,15 @@ use hyperlight_sandbox::{
 pub struct NanvixJavaScript;
 
 impl Guest for NanvixJavaScript {
+    type Sandbox = NanvixSandbox;
     fn build(
         self,
         _config: SandboxConfig,
         _tools: ToolRegistry,
         _network: std::sync::Arc<std::sync::Mutex<hyperlight_sandbox::NetworkPermissions>>,
         _fs: std::sync::Arc<std::sync::Mutex<hyperlight_sandbox::CapFs>>,
-    ) -> Result<Box<dyn GuestSandbox>> {
-        Ok(Box::new(NanvixSandbox::new(WorkloadType::JavaScript)?))
+    ) -> Result<NanvixSandbox> {
+        NanvixSandbox::new(WorkloadType::JavaScript)
     }
 }
 
@@ -45,14 +46,15 @@ impl Guest for NanvixJavaScript {
 pub struct NanvixPython;
 
 impl Guest for NanvixPython {
+    type Sandbox = NanvixSandbox;
     fn build(
         self,
         _config: SandboxConfig,
         _tools: ToolRegistry,
         _network: std::sync::Arc<std::sync::Mutex<hyperlight_sandbox::NetworkPermissions>>,
         _fs: std::sync::Arc<std::sync::Mutex<hyperlight_sandbox::CapFs>>,
-    ) -> Result<Box<dyn GuestSandbox>> {
-        Ok(Box::new(NanvixSandbox::new(WorkloadType::Python)?))
+    ) -> Result<NanvixSandbox> {
+        NanvixSandbox::new(WorkloadType::Python)
     }
 }
 
@@ -60,7 +62,7 @@ impl Guest for NanvixPython {
 // Sandbox implementation
 // ---------------------------------------------------------------------------
 
-struct NanvixSandbox {
+pub struct NanvixSandbox {
     workload_type: WorkloadType,
     runtime_config: RuntimeConfig,
     /// Tokio runtime for async nanvix API
@@ -90,7 +92,12 @@ impl NanvixSandbox {
     }
 }
 
+/// Unit type used as snapshot data for backends that don't support snapshotting.
+pub struct NoSnapshot;
+
 impl GuestSandbox for NanvixSandbox {
+    type SnapshotData = NoSnapshot;
+
     fn run(&mut self, code: &str) -> Result<ExecutionResult> {
         // Write code to a temporary file
         let mut tmp = tempfile::Builder::new()
@@ -133,13 +140,13 @@ impl GuestSandbox for NanvixSandbox {
         }
     }
 
-    fn snapshot(&mut self) -> Result<Snapshot> {
+    fn snapshot(&mut self) -> Result<Snapshot<NoSnapshot>> {
         Err(anyhow::anyhow!(
             "snapshot is not supported by the Nanvix sandbox"
         ))
     }
 
-    fn restore(&mut self, _snapshot: &Snapshot) -> Result<()> {
+    fn restore(&mut self, _snapshot: &Snapshot<NoSnapshot>) -> Result<()> {
         Err(anyhow::anyhow!(
             "restore is not supported by the Nanvix sandbox"
         ))

--- a/src/sdk/python/core/examples/benchmark.py
+++ b/src/sdk/python/core/examples/benchmark.py
@@ -197,7 +197,10 @@ def run_suite(name, backend, module=None, lang="python"):
 def main():
     all_results = {}
 
-    # Python in Wasm
+    # Python in Wasm — the defaults (25Mi heap / 35Mi stack) are sufficient.
+    # The Wasm guest embeds a full CPython interpreter (~44 MB AOT binary).
+    # Minimum viable: ~6 MiB heap, ~35 MiB stack (scratch must hold I/O
+    # buffers capped at min(heap, 70M) plus page tables and guest stacks).
     try:
         r = run_suite("Wasm + Python", backend="wasm", module="python_guest.path", lang="python")
         all_results["Wasm + Python"] = r

--- a/src/sdk/python/core/examples/python_basics.py
+++ b/src/sdk/python/core/examples/python_basics.py
@@ -25,7 +25,10 @@ def timed_run(sandbox, code, label="run"):
 # Create sandbox using the packaged python_guest artifact
 t0 = time.perf_counter()
 try:
-    sandbox = Sandbox(backend="wasm", module="python_guest.path")
+    sandbox = Sandbox(
+        backend="wasm",
+        module="python_guest.path",
+    )
 except ImportError as exc:
     raise SystemExit(
         "This example requires the Wasm backend and packaged Python guest package. "

--- a/src/sdk/python/core/hyperlight_sandbox/__init__.py
+++ b/src/sdk/python/core/hyperlight_sandbox/__init__.py
@@ -24,8 +24,8 @@ if platform.system() == "Windows":
     _DEFAULT_HEAP_SIZE = "400Mi"
     _DEFAULT_STACK_SIZE = "200Mi"
 else:
-    _DEFAULT_HEAP_SIZE = "200Mi"
-    _DEFAULT_STACK_SIZE = "100Mi"
+    _DEFAULT_HEAP_SIZE = "25Mi"
+    _DEFAULT_STACK_SIZE = "35Mi"
 
 
 def _normalize_backend(backend: str) -> str:

--- a/src/sdk/python/hyperlight_js_backend/src/lib.rs
+++ b/src/sdk/python/hyperlight_js_backend/src/lib.rs
@@ -2,17 +2,28 @@ use std::collections::HashMap;
 
 use hyperlight_javascript_sandbox::HyperlightJs;
 use hyperlight_sandbox::{
-    DEFAULT_HEAP_SIZE, DEFAULT_STACK_SIZE, DirPerms, FilePerms, HttpMethod, Sandbox, SandboxConfig,
+    DEFAULT_HEAP_SIZE, DEFAULT_STACK_SIZE, DirPerms, FilePerms, HttpMethod, Sandbox,
+    SandboxBuilder, SandboxConfig,
 };
 use hyperlight_sandbox_pyo3_common::{
-    PyExecutionResult, PySnapshot, build_tool_registry, parse_size, parse_tool_registration,
+    PyExecutionResult, build_tool_registry, parse_size, parse_tool_registration,
 };
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 
+type JsSandboxInner = Sandbox<HyperlightJs>;
+type JsSnapshotInner = hyperlight_sandbox::Snapshot<<
+    <HyperlightJs as hyperlight_sandbox::Guest>::Sandbox as hyperlight_sandbox::GuestSandbox
+>::SnapshotData>;
+
+#[pyclass]
+pub struct PySnapshot {
+    inner: JsSnapshotInner,
+}
+
 #[pyclass(unsendable)]
 pub struct JSSandbox {
-    inner: Option<Sandbox>,
+    inner: Option<JsSandboxInner>,
     tools: HashMap<String, Py<PyAny>>,
     pending_networks: Vec<(String, Option<Vec<String>>)>,
     config: SandboxConfig,
@@ -82,7 +93,7 @@ impl JSSandbox {
     fn run(&mut self, py: Python<'_>, code: &str) -> PyResult<PyExecutionResult> {
         if self.inner.is_none() {
             let registry = build_tool_registry(py, &mut self.tools)?;
-            let mut builder = Sandbox::builder()
+            let mut builder = SandboxBuilder::new()
                 .module_path(&self.config.module_path)
                 .heap_size(self.config.heap_size)
                 .stack_size(self.config.stack_size)

--- a/src/sdk/python/pyo3_common/src/lib.rs
+++ b/src/sdk/python/pyo3_common/src/lib.rs
@@ -1,4 +1,4 @@
-use hyperlight_sandbox::{ArgType, Snapshot, ToolRegistry, ToolSchema};
+use hyperlight_sandbox::{ArgType, ToolRegistry, ToolSchema};
 use pyo3::exceptions::{PyRuntimeError, PyTypeError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyModule};
@@ -396,12 +396,6 @@ fn py_value_to_arg_type(val: &Bound<'_, PyAny>) -> Option<ArgType> {
     } else {
         None
     }
-}
-
-/// Opaque snapshot handle exposed to Python.
-#[pyclass]
-pub struct PySnapshot {
-    pub inner: Snapshot,
 }
 
 /// Build a [`ToolRegistry`] from a map of Python callables.

--- a/src/sdk/python/wasm_backend/src/lib.rs
+++ b/src/sdk/python/wasm_backend/src/lib.rs
@@ -1,18 +1,29 @@
 use std::collections::HashMap;
 
 use hyperlight_sandbox::{
-    DEFAULT_HEAP_SIZE, DEFAULT_STACK_SIZE, DirPerms, FilePerms, HttpMethod, Sandbox, SandboxConfig,
+    DEFAULT_HEAP_SIZE, DEFAULT_STACK_SIZE, DirPerms, FilePerms, HttpMethod, Sandbox,
+    SandboxBuilder, SandboxConfig,
 };
 use hyperlight_sandbox_pyo3_common::{
-    PyExecutionResult, PySnapshot, build_tool_registry, parse_size, parse_tool_registration,
+    PyExecutionResult, build_tool_registry, parse_size, parse_tool_registration,
 };
 use hyperlight_wasm_sandbox::Wasm;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 
+type WasmSandboxInner = Sandbox<Wasm>;
+type WasmSnapshotInner = hyperlight_sandbox::Snapshot<<
+    <Wasm as hyperlight_sandbox::Guest>::Sandbox as hyperlight_sandbox::GuestSandbox
+>::SnapshotData>;
+
+#[pyclass]
+pub struct PySnapshot {
+    inner: WasmSnapshotInner,
+}
+
 #[pyclass(unsendable)]
 pub struct WasmSandbox {
-    inner: Option<Sandbox>,
+    inner: Option<WasmSandboxInner>,
     tools: HashMap<String, Py<PyAny>>,
     pending_networks: Vec<(String, Option<Vec<String>>)>,
     config: SandboxConfig,
@@ -76,7 +87,7 @@ impl WasmSandbox {
     fn run(&mut self, py: Python<'_>, code: &str) -> PyResult<PyExecutionResult> {
         if self.inner.is_none() {
             let registry = build_tool_registry(py, &mut self.tools)?;
-            let mut builder = Sandbox::builder()
+            let mut builder = SandboxBuilder::new()
                 .module_path(&self.config.module_path)
                 .heap_size(self.config.heap_size)
                 .stack_size(self.config.stack_size)

--- a/src/wasm_sandbox/examples/js_basics.rs
+++ b/src/wasm_sandbox/examples/js_basics.rs
@@ -8,7 +8,7 @@
 
 use std::path::Path;
 
-use hyperlight_sandbox::{DEFAULT_HEAP_SIZE, DEFAULT_STACK_SIZE, Sandbox, ToolRegistry};
+use hyperlight_sandbox::{SandboxBuilder, ToolRegistry};
 use hyperlight_wasm_sandbox::Wasm;
 use serde::Deserialize;
 
@@ -63,11 +63,9 @@ fn main() {
         Ok(serde_json::json!(val))
     });
 
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(Wasm)
         .module_path(javascript_guest_path())
-        .heap_size(DEFAULT_HEAP_SIZE)
-        .stack_size(DEFAULT_STACK_SIZE)
         .with_tools(tools)
         .build()
         .expect("failed to create JS sandbox");

--- a/src/wasm_sandbox/examples/js_filesystem_demo.rs
+++ b/src/wasm_sandbox/examples/js_filesystem_demo.rs
@@ -4,7 +4,7 @@
 
 use std::path::Path;
 
-use hyperlight_sandbox::{DirPerms, FilePerms, Sandbox};
+use hyperlight_sandbox::{DirPerms, FilePerms, SandboxBuilder};
 use hyperlight_wasm_sandbox::Wasm;
 
 fn javascript_guest_path() -> String {
@@ -21,7 +21,7 @@ fn separator(label: &str) {
 fn main() {
     // ── 1: No filesystem ────────────────────────────────────────────
     separator("Test 1: No filesystem");
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(Wasm)
         .module_path(javascript_guest_path())
         .build()
@@ -43,7 +43,7 @@ fn main() {
     let input_tmp = tempfile::tempdir().unwrap();
     std::fs::write(input_tmp.path().join("greeting.txt"), b"hello from host").unwrap();
 
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(Wasm)
         .module_path(javascript_guest_path())
         .input_dir(input_tmp.path())
@@ -65,7 +65,7 @@ fn main() {
 
     // ── 3: Temp output only ─────────────────────────────────────────
     separator("Test 3: Temp output only");
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(Wasm)
         .module_path(javascript_guest_path())
         .temp_output()
@@ -90,7 +90,7 @@ fn main() {
     let input_tmp = tempfile::tempdir().unwrap();
     std::fs::write(input_tmp.path().join("data.json"), br#"{"value": 42}"#).unwrap();
 
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(Wasm)
         .module_path(javascript_guest_path())
         .input_dir(input_tmp.path())
@@ -129,7 +129,7 @@ console.log('doubled: ' + doubled);
     let output_tmp = tempfile::tempdir().unwrap();
     std::fs::write(input_tmp.path().join("source.txt"), b"transform me").unwrap();
 
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(Wasm)
         .module_path(javascript_guest_path())
         .input_dir(input_tmp.path())
@@ -157,7 +157,7 @@ console.log('done');
 
     // ── 6: Output wiped between runs ────────────────────────────────
     separator("Test 6: Output is ephemeral");
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(Wasm)
         .module_path(javascript_guest_path())
         .temp_output()
@@ -187,7 +187,7 @@ console.log('done');
     let input_tmp = tempfile::tempdir().unwrap();
     std::fs::write(input_tmp.path().join("readonly.txt"), b"do not modify").unwrap();
 
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(Wasm)
         .module_path(javascript_guest_path())
         .input_dir(input_tmp.path())

--- a/src/wasm_sandbox/examples/js_network_demo.rs
+++ b/src/wasm_sandbox/examples/js_network_demo.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use hyperlight_sandbox::{DEFAULT_HEAP_SIZE, DEFAULT_STACK_SIZE, Sandbox};
+use hyperlight_sandbox::SandboxBuilder;
 use hyperlight_wasm_sandbox::Wasm;
 
 fn javascript_guest_path() -> String {
@@ -19,11 +19,9 @@ fn separator(title: &str) {
 }
 
 fn main() {
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(Wasm)
         .module_path(javascript_guest_path())
-        .heap_size(DEFAULT_HEAP_SIZE)
-        .stack_size(DEFAULT_STACK_SIZE)
         .build()
         .expect("failed to create JS sandbox");
     sandbox

--- a/src/wasm_sandbox/examples/python_basics.rs
+++ b/src/wasm_sandbox/examples/python_basics.rs
@@ -5,7 +5,7 @@
 
 use std::path::Path;
 
-use hyperlight_sandbox::{DEFAULT_HEAP_SIZE, DEFAULT_STACK_SIZE, Sandbox, ToolRegistry};
+use hyperlight_sandbox::{SandboxBuilder, ToolRegistry};
 use hyperlight_wasm_sandbox::Wasm;
 use serde::Deserialize;
 
@@ -60,11 +60,9 @@ fn main() {
         Ok(serde_json::json!(val))
     });
 
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(Wasm)
         .module_path(python_guest_path())
-        .heap_size(DEFAULT_HEAP_SIZE)
-        .stack_size(DEFAULT_STACK_SIZE)
         .with_tools(tools)
         .build()
         .expect("failed to create sandbox");

--- a/src/wasm_sandbox/examples/python_filesystem_demo.rs
+++ b/src/wasm_sandbox/examples/python_filesystem_demo.rs
@@ -4,7 +4,7 @@
 
 use std::path::Path;
 
-use hyperlight_sandbox::{DirPerms, FilePerms, Sandbox};
+use hyperlight_sandbox::{DirPerms, FilePerms, SandboxBuilder};
 use hyperlight_wasm_sandbox::Wasm;
 
 fn python_guest_path() -> String {
@@ -21,7 +21,7 @@ fn separator(label: &str) {
 fn main() {
     // ── 1: No filesystem ────────────────────────────────────────────
     separator("Test 1: No filesystem");
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(Wasm)
         .module_path(python_guest_path())
         .build()
@@ -43,7 +43,7 @@ fn main() {
     let input_tmp = tempfile::tempdir().unwrap();
     std::fs::write(input_tmp.path().join("greeting.txt"), b"hello from host").unwrap();
 
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(Wasm)
         .module_path(python_guest_path())
         .input_dir(input_tmp.path())
@@ -71,7 +71,7 @@ print(f"content: {content}")
 
     // ── 3: Temp output only ─────────────────────────────────────────
     separator("Test 3: Temp output only (writable preopen, no input)");
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(Wasm)
         .module_path(python_guest_path())
         .temp_output()
@@ -107,7 +107,7 @@ print('wrote output')
     let input_tmp = tempfile::tempdir().unwrap();
     std::fs::write(input_tmp.path().join("data.json"), br#"{"value": 42}"#).unwrap();
 
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(Wasm)
         .module_path(python_guest_path())
         .input_dir(input_tmp.path())
@@ -149,7 +149,7 @@ print(f"doubled: {result}")
     let output_tmp = tempfile::tempdir().unwrap();
     std::fs::write(input_tmp.path().join("source.txt"), b"transform me").unwrap();
 
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(Wasm)
         .module_path(python_guest_path())
         .input_dir(input_tmp.path())
@@ -188,7 +188,7 @@ print(f"transformed: {text.upper()}")
 
     // ── 6: Output is wiped between runs ─────────────────────────────
     separator("Test 6: Output is ephemeral (wiped between runs)");
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(Wasm)
         .module_path(python_guest_path())
         .temp_output()
@@ -235,7 +235,7 @@ print('wrote run2')
     let input_tmp = tempfile::tempdir().unwrap();
     std::fs::write(input_tmp.path().join("readonly.txt"), b"do not modify").unwrap();
 
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(Wasm)
         .module_path(python_guest_path())
         .input_dir(input_tmp.path())

--- a/src/wasm_sandbox/examples/python_network_demo.rs
+++ b/src/wasm_sandbox/examples/python_network_demo.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use hyperlight_sandbox::{DEFAULT_HEAP_SIZE, DEFAULT_STACK_SIZE, Sandbox};
+use hyperlight_sandbox::SandboxBuilder;
 use hyperlight_wasm_sandbox::Wasm;
 
 fn python_guest_path() -> String {
@@ -19,11 +19,9 @@ fn separator(title: &str) {
 }
 
 fn main() {
-    let mut sandbox = Sandbox::builder()
+    let mut sandbox = SandboxBuilder::new()
         .guest(Wasm)
         .module_path(python_guest_path())
-        .heap_size(DEFAULT_HEAP_SIZE)
-        .stack_size(DEFAULT_STACK_SIZE)
         .build()
         .expect("failed to create sandbox");
     sandbox

--- a/src/wasm_sandbox/src/lib.rs
+++ b/src/wasm_sandbox/src/lib.rs
@@ -24,15 +24,15 @@ pub(crate) mod bindings {
 pub struct Wasm;
 
 impl Guest for Wasm {
+    type Sandbox = WasmComponentSandbox;
     fn build(
         self,
         config: SandboxConfig,
         tools: ToolRegistry,
         network: std::sync::Arc<std::sync::Mutex<NetworkPermissions>>,
         fs: std::sync::Arc<std::sync::Mutex<CapFs>>,
-    ) -> Result<Box<dyn GuestSandbox>> {
+    ) -> Result<WasmComponentSandbox> {
         WasmComponentSandbox::with_tools(config, tools, network, fs)
-            .map(|sandbox| Box::new(sandbox) as Box<dyn GuestSandbox>)
     }
 }
 
@@ -216,7 +216,7 @@ impl bindings::hyperlight::sandbox::Tools for HostState {
     }
 }
 
-struct WasmComponentSandbox {
+pub struct WasmComponentSandbox {
     sandbox: bindings::RootSandbox<HostState, LoadedWasmSandbox>,
     fs: Arc<Mutex<CapFs>>,
 }
@@ -317,11 +317,13 @@ impl WasmComponentSandbox {
 }
 
 impl GuestSandbox for WasmComponentSandbox {
+    type SnapshotData = WasmSnapshot;
+
     fn run(&mut self, code: &str) -> Result<ExecutionResult> {
         self.run_impl(code)
     }
 
-    fn snapshot(&mut self) -> Result<Snapshot> {
+    fn snapshot(&mut self) -> Result<Snapshot<WasmSnapshot>> {
         let runtime = self
             .sandbox
             .sb
@@ -330,15 +332,10 @@ impl GuestSandbox for WasmComponentSandbox {
         Ok(Snapshot::new("wasm-component", runtime))
     }
 
-    fn restore(&mut self, snapshot: &Snapshot) -> Result<()> {
-        snapshot.restore::<WasmSnapshot>(
-            |rt| {
-                self.sandbox
-                    .sb
-                    .restore(rt)
-                    .map_err(|e| anyhow::anyhow!("restore failed: {e}"))
-            },
-            &self.fs,
-        )
+    fn restore(&mut self, snapshot: &Snapshot<WasmSnapshot>) -> Result<()> {
+        self.sandbox
+            .sb
+            .restore(snapshot.snapshot().clone())
+            .map_err(|e| anyhow::anyhow!("restore failed: {e}"))
     }
 }

--- a/src/wasm_sandbox/tests/http_wasm_integration.rs
+++ b/src/wasm_sandbox/tests/http_wasm_integration.rs
@@ -6,7 +6,7 @@
 use std::path::Path;
 
 use hyperlight_sandbox::test_utils::EchoServer;
-use hyperlight_sandbox::{DEFAULT_HEAP_SIZE, DEFAULT_STACK_SIZE, HttpMethod, Sandbox};
+use hyperlight_sandbox::{HttpMethod, SandboxBuilder};
 use hyperlight_wasm_sandbox::Wasm;
 
 fn python_guest_path() -> String {
@@ -22,11 +22,9 @@ async fn wasm_python_post_with_body() {
     let base_url = server.url("");
 
     let result = tokio::task::spawn_blocking(move || {
-        let mut sandbox = Sandbox::builder()
+        let mut sandbox = SandboxBuilder::new()
             .guest(Wasm)
             .module_path(python_guest_path())
-            .heap_size(DEFAULT_HEAP_SIZE)
-            .stack_size(DEFAULT_STACK_SIZE)
             .build()
             .expect("failed to create sandbox");
 
@@ -59,11 +57,9 @@ async fn wasm_python_get_request() {
     let base_url = server.url("");
 
     let result = tokio::task::spawn_blocking(move || {
-        let mut sandbox = Sandbox::builder()
+        let mut sandbox = SandboxBuilder::new()
             .guest(Wasm)
             .module_path(python_guest_path())
-            .heap_size(DEFAULT_HEAP_SIZE)
-            .stack_size(DEFAULT_STACK_SIZE)
             .build()
             .expect("failed to create sandbox");
 
@@ -97,11 +93,9 @@ async fn wasm_python_post_large_body_streams_in_chunks() {
     let base_url = server.url("");
 
     let result = tokio::task::spawn_blocking(move || {
-        let mut sandbox = Sandbox::builder()
+        let mut sandbox = SandboxBuilder::new()
             .guest(Wasm)
             .module_path(python_guest_path())
-            .heap_size(DEFAULT_HEAP_SIZE)
-            .stack_size(DEFAULT_STACK_SIZE)
             .build()
             .expect("failed to create sandbox");
 


### PR DESCRIPTION
This removes some overhead from box/unboxing and shrinks the size of the sandbox defaults. which increases performance and makes it more inline with the raw hl versions.  There is some overhead when using the python SDK but its minimal.