### PR TITLE
fix: pin wasmtime 36.0.6 to match AOT compiler

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # wasmtime (indirect, via hyperlight-wasm) must stay aligned with the
+      # hyperlight-wasm-aot CLI that compiles .aot guest binaries.  The AOT
+      # compiler is installed from a pinned git rev and uses its own Cargo.lock,
+      # so a workspace-only bump creates a version mismatch at runtime.
+      # Update wasmtime only when hyperlight-wasm itself is updated.
+      - dependency-name: "wasmtime"
+      - dependency-name: "wasmtime-*"
 
   # Rust (Python wasm backend — separate workspace)
   - package-ecosystem: "cargo"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,23 +745,23 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.123.7"
+version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1da85f2636fe28244848861d1ed0f8dccdc6e98fc5db31aa5eb8878e7ff617"
+checksum = "0230a6ac0660bfe31eb244cbb43dcd4f2b3c1c4e0addc3e0348c6053ea60272e"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64 0.123.7",
  "cranelift-bforest 0.123.7",
  "cranelift-bitset 0.123.7",
- "cranelift-codegen-meta 0.123.7",
+ "cranelift-codegen-meta 0.123.6",
  "cranelift-codegen-shared 0.123.7",
  "cranelift-control 0.123.7",
  "cranelift-entity 0.123.7",
- "cranelift-isle 0.123.7",
+ "cranelift-isle 0.123.6",
  "gimli 0.32.3",
  "hashbrown 0.15.5",
  "log",
- "pulley-interpreter 36.0.7",
+ "pulley-interpreter 36.0.6",
  "regalloc2 0.12.2",
  "rustc-hash",
  "serde",
@@ -800,15 +800,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.123.7"
+version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3c8aba9d89832df27364b2e79dc2fe288daf4bd6c7347829e7f3f258ea5650"
+checksum = "96d6817fdc15cb8f236fc9d8e610767d3a03327ceca4abff7a14d8e2154c405e"
 dependencies = [
  "cranelift-assembler-x64-meta 0.123.7",
  "cranelift-codegen-shared 0.123.7",
  "cranelift-srcgen 0.123.7",
  "heck",
- "pulley-interpreter 36.0.7",
+ "pulley-interpreter 36.0.6",
 ]
 
 [[package]]
@@ -879,11 +879,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.123.7"
+version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa1d2006915cddb63705db46dcfb8637fe08f91d26fbe59680d7257ec39d609"
+checksum = "ea5440792eb2b5ba0a0976df371b9f94031bd853ae56f389de610bca7128a7cb"
 dependencies = [
- "cranelift-codegen 0.123.7",
+ "cranelift-codegen 0.123.6",
  "log",
  "smallvec",
  "target-lexicon",
@@ -903,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.123.7"
+version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4fecbcbb81273f9aff4559e26fc341f42663da420cca5ac84b34e74e9267e0"
+checksum = "1e5c05fab6fce38d729088f3fa1060eaa1ad54eefd473588887205ed2ab2f79e"
 
 [[package]]
 name = "cranelift-isle"
@@ -915,11 +915,11 @@ checksum = "f1153844610cc9c6da8cf10ce205e45da1a585b7688ed558aa808bbe2e4e6d77"
 
 [[package]]
 name = "cranelift-native"
-version = "0.123.7"
+version = "0.123.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976a3d85f197a56ae34ee4d5a5e469855ac52804a09a513d0562d425da0ff56e"
+checksum = "9c9a0607a028edf5ba5bba7e7cf5ca1b7f0a030e3ae84dcd401e8b9b05192280"
 dependencies = [
- "cranelift-codegen 0.123.7",
+ "cranelift-codegen 0.123.6",
  "libc",
  "target-lexicon",
 ]
@@ -1093,7 +1093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1912,7 +1912,7 @@ dependencies = [
  "reqwest",
  "spin",
  "tracing",
- "wasmtime 36.0.7",
+ "wasmtime 36.0.6",
 ]
 
 [[package]]
@@ -2106,7 +2106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2811,13 +2811,13 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "36.0.7"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a078b4bdfd275fadeefc4f9ae3675ee5af302e69497da439956dd05257858970"
+checksum = "499d922aa0f9faac8d92351416664f1b7acd914008a90fce2f0516d31efddf67"
 dependencies = [
  "cranelift-bitset 0.123.7",
  "log",
- "pulley-macros 36.0.7",
+ "pulley-macros 36.0.6",
  "wasmtime-internal-math",
 ]
 
@@ -2835,9 +2835,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "36.0.7"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dac91999883fd00b900eb5377be403c5cb8b93e10efcb571bf66454c2d9f231"
+checksum = "a3848fb193d6dffca43a21f24ca9492f22aab88af1223d06bac7f8a0ef405b81"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2971,7 +2971,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3372,7 +3372,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3511,7 +3511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3778,7 +3778,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4363,9 +4363,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "36.0.7"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b80d5ba38b9b00f60a0665e07dde38e91d884d4a78cd61d777c8cf081a1267c1"
+checksum = "6a2f8736ddc86e03a9d0e4c477a37939cfc53cd1b052ee38a3133679b87ef830"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
@@ -4381,23 +4381,23 @@ dependencies = [
  "memfd",
  "object 0.37.3",
  "postcard",
- "pulley-interpreter 36.0.7",
+ "pulley-interpreter 36.0.6",
  "semver",
  "serde",
  "serde_derive",
  "smallvec",
  "target-lexicon",
  "wasmparser 0.236.1",
- "wasmtime-environ 36.0.7",
+ "wasmtime-environ 36.0.6",
  "wasmtime-internal-asm-macros",
- "wasmtime-internal-component-macro 36.0.7",
- "wasmtime-internal-component-util 36.0.7",
- "wasmtime-internal-cranelift 36.0.7",
+ "wasmtime-internal-component-macro 36.0.6",
+ "wasmtime-internal-component-util 36.0.6",
+ "wasmtime-internal-cranelift 36.0.6",
  "wasmtime-internal-math",
  "wasmtime-internal-slab",
- "wasmtime-internal-unwinder 36.0.7",
- "wasmtime-internal-versioned-export-macros 36.0.7",
- "wasmtime-internal-winch 36.0.7",
+ "wasmtime-internal-unwinder 36.0.6",
+ "wasmtime-internal-versioned-export-macros 36.0.6",
+ "wasmtime-internal-winch 36.0.6",
  "windows-sys 0.60.2",
 ]
 
@@ -4445,9 +4445,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "36.0.7"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44a45d60dea98308decb71a9f7bb35a629696d1fbf7127dbfde42cbc64b8fa33"
+checksum = "733682a327755c77153ac7455b1ba8f2db4d9946c1738f8002fe1fbda1d52e83"
 dependencies = [
  "anyhow",
  "cranelift-bitset 0.123.7",
@@ -4465,7 +4465,7 @@ dependencies = [
  "wasm-encoder 0.236.1",
  "wasmparser 0.236.1",
  "wasmprinter 0.236.1",
- "wasmtime-internal-component-util 36.0.7",
+ "wasmtime-internal-component-util 36.0.6",
 ]
 
 [[package]]
@@ -4499,25 +4499,25 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "36.0.7"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd014b4001b6da03d79062d9ad5ec98fa62e34d50e30e46298545282cc2957e4"
+checksum = "68288980a2e02bcb368d436da32565897033ea21918007e3f2bae18843326cf9"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "36.0.7"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2942aa5d44b02061e0c6ab71b23090cf3b300b4519e3b80776ac38edde2e65"
+checksum = "5dea846da68f8e776c8a43bde3386022d7bb74e713b9654f7c0196e5ff2e4684"
 dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
  "syn",
- "wasmtime-internal-component-util 36.0.7",
- "wasmtime-internal-wit-bindgen 36.0.7",
+ "wasmtime-internal-component-util 36.0.6",
+ "wasmtime-internal-wit-bindgen 36.0.6",
  "wit-parser 0.236.1",
 ]
 
@@ -4538,9 +4538,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "36.0.7"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcb6f974fe739e98034b7e6ec6feb2ab399f4cde7207675f26138bd9a1d65720"
+checksum = "fe1e5735b3c8251510d2a55311562772d6c6fca9438a3d0329eb6e38af4957d6"
 
 [[package]]
 name = "wasmtime-internal-component-util"
@@ -4561,29 +4561,29 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "36.0.7"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4047020866a80aa943e41133e607020e17562126cf81533362275272098a22b1"
+checksum = "e89bb9ef571288e2be6b8a3c4763acc56c348dcd517500b1679d3ffad9e4a757"
 dependencies = [
  "anyhow",
  "cfg-if",
- "cranelift-codegen 0.123.7",
+ "cranelift-codegen 0.123.6",
  "cranelift-control 0.123.7",
  "cranelift-entity 0.123.7",
- "cranelift-frontend 0.123.7",
- "cranelift-native 0.123.7",
+ "cranelift-frontend 0.123.6",
+ "cranelift-native 0.123.6",
  "gimli 0.32.3",
  "itertools 0.14.0",
  "log",
  "object 0.37.3",
- "pulley-interpreter 36.0.7",
+ "pulley-interpreter 36.0.6",
  "smallvec",
  "target-lexicon",
  "thiserror",
  "wasmparser 0.236.1",
- "wasmtime-environ 36.0.7",
+ "wasmtime-environ 36.0.6",
  "wasmtime-internal-math",
- "wasmtime-internal-versioned-export-macros 36.0.7",
+ "wasmtime-internal-versioned-export-macros 36.0.6",
 ]
 
 [[package]]
@@ -4652,24 +4652,24 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "36.0.7"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3a1f51a037ae2c048f0d76d36e27f0d22276295496c44f16a251f24690e003"
+checksum = "5a23b03fb14c64bd0dfcaa4653101f94ade76c34a3027ed2d6b373267536e45b"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "36.0.7"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6171aac3d66e4d69e50080bb6bc5205de2283513984a4118a93cb66dc02994"
+checksum = "fbff220b88cdb990d34a20b13344e5da2e7b99959a5b1666106bec94b58d6364"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "36.0.7"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd1bc1783391a02176fb687159b1779fc10b71d5350adf09c1f3aa8442a02cc"
+checksum = "13e1ad30e88988b20c0d1c56ea4b4fbc01a8c614653cbf12ca50c0dcc695e2f7"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4692,9 +4692,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "36.0.7"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8097e2c8ca02ed65d31dda111faa0888ffbf28dc3ee74355e283118a8d293eb0"
+checksum = "549aefdaa1398c2fcfbf69a7b882956bb5b6e8e5b600844ecb91a3b5bf658ca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4714,19 +4714,19 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "36.0.7"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8cb36b61fbcff2c8bcd14f9f2651a6e52b019d0d329324620d7bc971b2b235"
+checksum = "5cc96a84c5700171aeecf96fa9a9ab234f333f5afb295dabf3f8a812b70fe832"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.123.7",
+ "cranelift-codegen 0.123.6",
  "gimli 0.32.3",
  "object 0.37.3",
  "target-lexicon",
  "wasmparser 0.236.1",
- "wasmtime-environ 36.0.7",
- "wasmtime-internal-cranelift 36.0.7",
- "winch-codegen 36.0.7",
+ "wasmtime-environ 36.0.6",
+ "wasmtime-internal-cranelift 36.0.6",
+ "winch-codegen 36.0.6",
 ]
 
 [[package]]
@@ -4748,9 +4748,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "36.0.7"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff555cfb71577028616d65c00221c7fe6eef45a9ebb96fc6d34d4a41fa1de191"
+checksum = "c28dc9efea511598c88564ac1974e0825c07d9c0de902dbf68f227431cd4ff8c"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
@@ -4907,7 +4907,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4918,21 +4918,21 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "36.0.7"
+version = "36.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0989126b21d12c9923aa2de7ddbcf87db03037b24b7365041d9dd0095b69d8cb"
+checksum = "06c0ec09e8eb5e850e432da6271ed8c4a9d459a9db3850c38e98a3ee9d015e79"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64 0.123.7",
- "cranelift-codegen 0.123.7",
+ "cranelift-codegen 0.123.6",
  "gimli 0.32.3",
  "regalloc2 0.12.2",
  "smallvec",
  "target-lexicon",
  "thiserror",
  "wasmparser 0.236.1",
- "wasmtime-environ 36.0.7",
- "wasmtime-internal-cranelift 36.0.7",
+ "wasmtime-environ 36.0.6",
+ "wasmtime-internal-cranelift 36.0.6",
  "wasmtime-internal-math",
 ]
 

--- a/src/wasm_sandbox/Justfile
+++ b/src/wasm_sandbox/Justfile
@@ -9,16 +9,18 @@ rmrf := if os() == "windows" { "Remove-Item -Recurse -Force -ErrorAction Silentl
 ensure-tools:
     @command -v clang >/dev/null 2>&1 || { echo "clang not found — install with: apt install clang or brew install llvm"; exit 1; }
     @command -v wasm-tools >/dev/null 2>&1 || cargo install wasm-tools --locked
-    @command -v hyperlight-wasm-aot >/dev/null 2>&1 || \
-        cargo install hyperlight-wasm-aot \
-            --git https://github.com/jsturtevant/hyperlight-wasm \
-            --rev 09b5e8297d827518847c08c8506bf83e85eb89b1
+    # Always force-install: cargo install skips when the same rev is cached,
+    # even if the cached binary was compiled with different dependency versions
+    # (e.g. a stale wasmtime patch from the CI Cargo bin cache).
+    cargo install hyperlight-wasm-aot --locked --force \
+        --git https://github.com/jsturtevant/hyperlight-wasm \
+        --rev 09b5e8297d827518847c08c8506bf83e85eb89b1
 
 [windows]
 ensure-tools:
     if (-not (Get-Command clang -ErrorAction SilentlyContinue)) { Write-Error 'clang not found — install with: winget install LLVM.LLVM'; exit 1 }; \
     if (-not (Get-Command wasm-tools -ErrorAction SilentlyContinue)) { cargo install wasm-tools --locked }; \
-    if (-not (Get-Command hyperlight-wasm-aot -ErrorAction SilentlyContinue)) { cargo install hyperlight-wasm-aot --git https://github.com/jsturtevant/hyperlight-wasm --rev 09b5e8297d827518847c08c8506bf83e85eb89b1 }
+    cargo install hyperlight-wasm-aot --locked --force --git https://github.com/jsturtevant/hyperlight-wasm --rev 09b5e8297d827518847c08c8506bf83e85eb89b1
 
 guest-build-wasm: ensure-tools
     cd {{repo-root}}/src/wasm_sandbox/guests/python && uv run componentize-py \


### PR DESCRIPTION
## Problem

The dependabot bump to wasmtime 36.0.7 (commit 7a88a5e, PR #35) caused a version mismatch between the runtime and the AOT compiler:

- **Runtime** (`hyperlight-wasm-runtime`): built from the workspace `Cargo.lock` → wasmtime **36.0.7**
- **AOT compiler** (`hyperlight-wasm-aot`): installed via `cargo install --git --rev` with its own `Cargo.lock` → wasmtime **36.0.6**

Guest `.aot` files compiled with 36.0.6 cannot be loaded by a 36.0.7 runtime, causing all WASM sandbox and Python SDK CI jobs to fail with:

```
Module was compiled with incompatible Wasmtime version '36.0.7'
```

## Fix

1. Pin wasmtime back to 36.0.6 in `Cargo.lock` (`cargo update wasmtime@36.0.7 --precise 36.0.6`)
2. Exclude `wasmtime` and `wasmtime-*` from dependabot auto-bumps — these must be updated in lockstep with the `hyperlight-wasm` dependency

## Root cause

The AOT compiler is installed from a pinned git rev of `hyperlight-wasm`, which resolves its own dependencies independently of the workspace `Cargo.lock`. Any wasmtime patch bump in the workspace creates a version mismatch.