### PR TITLE
Fix publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,6 +137,17 @@ jobs:
           cache-key: release-windows-dotnet
           rustflags: ""
 
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+
+      - name: Install Python
+        run: uv python install 3.12
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: "latest"
+          cache: npm
+          cache-dependency-path: src/wasm_sandbox/guests/javascript/package-lock.json
+
       - name: Install just
         run: cargo install --locked just
 
@@ -181,6 +192,17 @@ jobs:
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5.2.0
         with:
           dotnet-version: '8.0.x'
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+
+      - name: Install Python
+        run: uv python install 3.12
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: "latest"
+          cache: npm
+          cache-dependency-path: src/wasm_sandbox/guests/javascript/package-lock.json
 
       - name: Install just
         run: cargo install --locked just

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,6 +137,9 @@ jobs:
           just wasm build release
           just js build release
 
+      - name: Compile WIT world
+        run: just wasm guest-compile-wit
+
       - name: Build Windows native library
         run: just dotnet build-rust release
 
@@ -185,6 +188,9 @@ jobs:
         run: |
           just wasm build release
           just js build release
+
+      - name: Compile WIT world
+        run: just wasm guest-compile-wit
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -154,10 +154,11 @@ jobs:
       - name: Install LLVM
         run: choco install llvm -y
 
-      - name: Build sandbox runtimes
-        run: |
-          just wasm build release
-          just js build release
+      - name: Build WASM sandbox runtime
+        run: just wasm build release
+
+      - name: Build JavaScript sandbox runtime
+        run: just js build release
 
       - name: Compile WIT world
         run: just wasm guest-compile-wit
@@ -217,10 +218,11 @@ jobs:
           sudo udevadm trigger --name-match=kvm
           sudo chmod 666 /dev/kvm
 
-      - name: Build sandbox runtimes
-        run: |
-          just wasm build release
-          just js build release
+      - name: Build WASM sandbox runtime
+        run: just wasm build release
+
+      - name: Build JavaScript sandbox runtime
+        run: just js build release
 
       - name: Compile WIT world
         run: just wasm guest-compile-wit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,17 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      publish_target:
+        description: "What to run"
+        required: true
+        type: choice
+        options:
+          - all
+          - python
+          - dotnet
+        default: all
 
 permissions:
   contents: read
@@ -11,7 +22,7 @@ permissions:
 jobs:
   # Build all Python packages on Linux (pure + backend wheels).
   build-linux:
-    if: ${{ !github.event.act }}
+    if: ${{ !github.event.act && (github.event_name != 'workflow_dispatch' || inputs.publish_target == 'all' || inputs.publish_target == 'python') }}
     name: Build Linux packages
     runs-on: ubuntu-latest
     steps:
@@ -51,7 +62,7 @@ jobs:
 
   # Build Windows-specific maturin backend wheels only.
   build-windows:
-    if: ${{ !github.event.act }}
+    if: ${{ !github.event.act && (github.event_name != 'workflow_dispatch' || inputs.publish_target == 'all' || inputs.publish_target == 'python') }}
     name: Build Windows backend wheels
     runs-on: windows-latest
     steps:
@@ -87,7 +98,7 @@ jobs:
 
   # Merge artifacts from both platforms and publish to PyPI.
   publish:
-    if: ${{ !github.event.act }}
+    if: ${{ !github.event.act && (github.event_name != 'workflow_dispatch' || inputs.publish_target == 'all' || inputs.publish_target == 'python') }}
     name: Publish to PyPI
     needs: [build-linux, build-windows]
     runs-on: ubuntu-latest
@@ -115,7 +126,7 @@ jobs:
 
   # Build the Windows native library for the .NET P/Invoke NuGet package.
   dotnet-build-windows:
-    if: ${{ !github.event.act }}
+    if: ${{ !github.event.act && (github.event_name != 'workflow_dispatch' || inputs.publish_target == 'all' || inputs.publish_target == 'dotnet') }}
     name: Build Windows .NET native library
     runs-on: windows-latest
     steps:
@@ -150,7 +161,7 @@ jobs:
 
   # Build and publish .NET NuGet packages.
   dotnet-publish:
-    if: ${{ !github.event.act }}
+    if: ${{ !github.event.act && (github.event_name != 'workflow_dispatch' || inputs.publish_target == 'all' || inputs.publish_target == 'dotnet') }}
     name: Publish .NET NuGet packages
     needs: [dotnet-build-windows]
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,7 +1725,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-javascript-sandbox"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "hyperlight-js",
@@ -1782,7 +1782,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-sandbox"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-sandbox-backend-hyperlight-js"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hyperlight-javascript-sandbox",
  "hyperlight-sandbox",
@@ -1816,7 +1816,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-sandbox-backend-wasm"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hyperlight-sandbox",
  "hyperlight-sandbox-pyo3-common",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-sandbox-dotnet-ffi"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "hyperlight-javascript-sandbox",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-sandbox-pyo3-common"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "hyperlight-sandbox",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-wasm-sandbox"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bytes",


### PR DESCRIPTION
Published failed because the windows build didn't have the wasm wit world available.  This fixes it and adds ability to manually trigger the individual builds package platforms which lets us not have to retag a version since there were no code changes.