### PR TITLE
Update Hyperlight components for bindgen fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1af5a01adeeade54c9f5060300227a8ee64c05b6376f28e9b8ee3b72dd2056f"
 dependencies = [
- "spin",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -261,6 +261,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 dependencies = [
  "allocator-api2",
+]
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -388,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-hyperlight"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8db26640559cfddd11806fcf29e3103590b625d6f80878f6bfe4874f6e2509b1"
+checksum = "416fd0f4dc4e1e972da8365f840bf95a708f92d233377f0210b167739dfde736"
 dependencies = [
  "anyhow",
  "clap",
@@ -629,9 +649,9 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -671,11 +691,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.123.7"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8056d63fef9a6f88a1e7aae52bb08fcf48de8866d514c0dc52feb15975f5db5"
+checksum = "2ad3e7d446bbdc05f33371b17aae2857e2c5f1dd6750848f555c129c5060725f"
 dependencies = [
- "cranelift-assembler-x64-meta 0.123.7",
+ "cranelift-assembler-x64-meta 0.123.11",
 ]
 
 [[package]]
@@ -689,11 +709,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.123.7"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d063b40884a0d733223a45c5de1155395af4393cf7f900d5be8e2cbc094015"
+checksum = "96ee145f9cbf7474350ee48e5c33ec2312177fa32c07e4eb395727250892a201"
 dependencies = [
- "cranelift-srcgen 0.123.7",
+ "cranelift-srcgen 0.123.11",
 ]
 
 [[package]]
@@ -707,11 +727,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.123.7"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3add2881bae2d55cd7162906988dd70053cb7ece865ad793a6754b04d47df6"
+checksum = "7025668e34c499fd0960dfaf68bc1689c961002fb67227f3dd262535c4118e52"
 dependencies = [
- "cranelift-entity 0.123.7",
+ "cranelift-entity 0.123.11",
 ]
 
 [[package]]
@@ -726,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.123.7"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd73e32bc1ea4bddc4c770760c66fa24b2890991b0561af554219e603fcd7c34"
+checksum = "4ad0b552e9b906fee4416b68664463e80f9024215da2cebd4065eee99d5d3008"
 dependencies = [
  "serde",
  "serde_derive",
@@ -747,23 +767,23 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.123.7"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1da85f2636fe28244848861d1ed0f8dccdc6e98fc5db31aa5eb8878e7ff617"
+checksum = "f87371fa1b0e21dc0a7943f372ce5a308c7d6b26ef8c9982a8a063218fe101ae"
 dependencies = [
  "bumpalo",
- "cranelift-assembler-x64 0.123.7",
- "cranelift-bforest 0.123.7",
- "cranelift-bitset 0.123.7",
- "cranelift-codegen-meta 0.123.7",
- "cranelift-codegen-shared 0.123.7",
- "cranelift-control 0.123.7",
- "cranelift-entity 0.123.7",
- "cranelift-isle 0.123.7",
+ "cranelift-assembler-x64 0.123.11",
+ "cranelift-bforest 0.123.11",
+ "cranelift-bitset 0.123.11",
+ "cranelift-codegen-meta 0.123.11",
+ "cranelift-codegen-shared 0.123.11",
+ "cranelift-control 0.123.11",
+ "cranelift-entity 0.123.11",
+ "cranelift-isle 0.123.11",
  "gimli 0.32.3",
  "hashbrown 0.15.5",
  "log",
- "pulley-interpreter 36.0.7",
+ "pulley-interpreter 36.0.11",
  "regalloc2 0.12.2",
  "rustc-hash",
  "serde",
@@ -802,15 +822,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.123.7"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3c8aba9d89832df27364b2e79dc2fe288daf4bd6c7347829e7f3f258ea5650"
+checksum = "a24ef297d4dd3af3e571691568958ceea1d3e723bb24eef4e934bbd569c93ef6"
 dependencies = [
- "cranelift-assembler-x64-meta 0.123.7",
- "cranelift-codegen-shared 0.123.7",
- "cranelift-srcgen 0.123.7",
+ "cranelift-assembler-x64-meta 0.123.11",
+ "cranelift-codegen-shared 0.123.11",
+ "cranelift-srcgen 0.123.11",
  "heck",
- "pulley-interpreter 36.0.7",
+ "pulley-interpreter 36.0.11",
 ]
 
 [[package]]
@@ -828,9 +848,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.123.7"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9a9b09fe107fef6377caed20614586124184cffccb73611312ceb922a917e6"
+checksum = "d65396f589d1f746f52db7370372bc8611aa7a5bc0b0322f77deaa1b62e12287"
 
 [[package]]
 name = "cranelift-codegen-shared"
@@ -840,9 +860,9 @@ checksum = "879f77c497a1eb6273482aa1ac3b23cb8563ff04edb39ed5dfcfd28c8deff8f5"
 
 [[package]]
 name = "cranelift-control"
-version = "0.123.7"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50aef001c7ad250d5fdda2c7481cbfcabe6435c66106adf5760dcb9fb9a8ede4"
+checksum = "a5731530f81a1566057f9475639f34463e723210ef2484fe9f087e03d79e879a"
 dependencies = [
  "arbitrary",
 ]
@@ -858,11 +878,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-entity"
-version = "0.123.7"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3c84656a010df2b5afaedcbbbd94f1efe175b55e29864df7b99e64bfa40d56"
+checksum = "3437f152d3766d07420956f4eabaa6f89fa98543e53d387dd1e395980441c68d"
 dependencies = [
- "cranelift-bitset 0.123.7",
+ "cranelift-bitset 0.123.11",
  "serde",
  "serde_derive",
 ]
@@ -881,11 +901,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.123.7"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa1d2006915cddb63705db46dcfb8637fe08f91d26fbe59680d7257ec39d609"
+checksum = "c9dbb5c65123d9bd76a701523d72f78e1f9b754321caa7767a70ea9304f49be1"
 dependencies = [
- "cranelift-codegen 0.123.7",
+ "cranelift-codegen 0.123.11",
  "log",
  "smallvec",
  "target-lexicon",
@@ -905,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.123.7"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4fecbcbb81273f9aff4559e26fc341f42663da420cca5ac84b34e74e9267e0"
+checksum = "a493c7a6e01f9c6e9b5468faa7f13a06d6d882f92942f8042a0fd0a8e3e8bc2c"
 
 [[package]]
 name = "cranelift-isle"
@@ -917,11 +937,11 @@ checksum = "f62dd18116d88bed649871feceda79dad7b59cc685ea8998c2b3e64d0e689602"
 
 [[package]]
 name = "cranelift-native"
-version = "0.123.7"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976a3d85f197a56ae34ee4d5a5e469855ac52804a09a513d0562d425da0ff56e"
+checksum = "79bd8bd6a0a5bce75e9b24b4e9578114ef6be94795956c4d19aeaa1da607abfd"
 dependencies = [
- "cranelift-codegen 0.123.7",
+ "cranelift-codegen 0.123.11",
  "libc",
  "target-lexicon",
 ]
@@ -939,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.123.7"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fbd4aefce642145491ff862d2054a71b63d2d97b8dd1e280c9fdaf399598b7"
+checksum = "7c33438ba0b8ba75137bd45eb0d36a319efe90cf145f9fd5773b84f0b89f0edc"
 
 [[package]]
 name = "cranelift-srcgen"
@@ -984,6 +1004,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,7 +1046,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1095,7 +1129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1446,6 +1480,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1473,6 +1513,8 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
  "serde",
  "serde_core",
@@ -1582,14 +1624,16 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-common"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2d385987047c64fdb5c95e05ef3b6bd9431001a8fe694abb29b29e99913167"
+version = "0.15.0"
+source = "git+https://github.com/jsturtevant/hyperlight-1?rev=0fedd53253cc8b84f9d3e341bea181fd8db204d5#0fedd53253cc8b84f9d3e341bea181fd8db204d5"
 dependencies = [
  "anyhow",
+ "bitflags 2.13.0",
+ "bytemuck",
  "flatbuffers",
  "log",
- "spin",
+ "smallvec",
+ "spin 0.12.0",
  "thiserror",
  "tracing",
  "tracing-core",
@@ -1597,39 +1641,36 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-component-macro"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7ae5cd7c8e5f5b925b07bce45be853ac0be0e6d4e8b2afd17ad8c16aa135c4"
+version = "0.15.0"
+source = "git+https://github.com/jsturtevant/hyperlight-1?rev=0fedd53253cc8b84f9d3e341bea181fd8db204d5#0fedd53253cc8b84f9d3e341bea181fd8db204d5"
 dependencies = [
  "env_logger",
  "hyperlight-component-util",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "prettyplease",
  "proc-macro2",
  "quote",
  "syn",
- "wasmparser 0.246.2",
 ]
 
 [[package]]
 name = "hyperlight-component-util"
-version = "0.14.0"
-source = "git+https://github.com/jsturtevant/hyperlight-1?rev=cdbed80af127b4d74e2633511cadb07bfea0160e#cdbed80af127b4d74e2633511cadb07bfea0160e"
+version = "0.15.0"
+source = "git+https://github.com/jsturtevant/hyperlight-1?rev=0fedd53253cc8b84f9d3e341bea181fd8db204d5#0fedd53253cc8b84f9d3e341bea181fd8db204d5"
 dependencies = [
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "prettyplease",
  "proc-macro2",
  "quote",
  "syn",
  "tracing",
- "wasmparser 0.247.0",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
 name = "hyperlight-guest"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee2682d284171d2bd9e80e3e543de310356c1d8ec65e88028b3e08048d15d3d"
+version = "0.15.0"
+source = "git+https://github.com/jsturtevant/hyperlight-1?rev=0fedd53253cc8b84f9d3e341bea181fd8db204d5#0fedd53253cc8b84f9d3e341bea181fd8db204d5"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -1640,30 +1681,26 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest-bin"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3740817f3be98d18edb50eec985461baca0eba5b1f73d0f475b7a539d812e750"
+version = "0.15.0"
+source = "git+https://github.com/jsturtevant/hyperlight-1?rev=0fedd53253cc8b84f9d3e341bea181fd8db204d5#0fedd53253cc8b84f9d3e341bea181fd8db204d5"
 dependencies = [
  "buddy_system_allocator",
- "cc",
- "cfg-if",
  "flatbuffers",
- "glob",
  "hyperlight-common",
  "hyperlight-guest",
  "hyperlight-guest-macro",
  "hyperlight-guest-tracing",
+ "hyperlight-libc",
  "linkme",
  "log",
- "spin",
+ "spin 0.12.0",
  "tracing",
 ]
 
 [[package]]
 name = "hyperlight-guest-macro"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4f88cbcde1ca986e4f14a85ea0a436659edcb6eb63e8a9d14413ca5cdc8ea86"
+version = "0.15.0"
+source = "git+https://github.com/jsturtevant/hyperlight-1?rev=0fedd53253cc8b84f9d3e341bea181fd8db204d5#0fedd53253cc8b84f9d3e341bea181fd8db204d5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1673,25 +1710,24 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest-tracing"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d14e9c34c508ecfba1283a552c3eb118d8ee82d863e2e91377a6059f06cf84dd"
+version = "0.15.0"
+source = "git+https://github.com/jsturtevant/hyperlight-1?rev=0fedd53253cc8b84f9d3e341bea181fd8db204d5#0fedd53253cc8b84f9d3e341bea181fd8db204d5"
 dependencies = [
  "hyperlight-common",
- "spin",
+ "spin 0.12.0",
  "tracing",
  "tracing-core",
 ]
 
 [[package]]
 name = "hyperlight-host"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c2f9b5a13324c5dd786bf77a7531216207684da1cefc19fb9b697d08346ac0"
+version = "0.15.0"
+source = "git+https://github.com/jsturtevant/hyperlight-1?rev=0fedd53253cc8b84f9d3e341bea181fd8db204d5#0fedd53253cc8b84f9d3e341bea181fd8db204d5"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
  "blake3",
+ "bytemuck",
  "cfg-if",
  "cfg_aliases",
  "crossbeam-channel",
@@ -1714,7 +1750,6 @@ dependencies = [
  "thiserror",
  "tracing",
  "tracing-core",
- "tracing-log",
  "uuid",
  "vmm-sys-util",
  "windows",
@@ -1738,8 +1773,8 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-js"
-version = "0.2.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight-js.git?rev=dd118685db5da1aca3c22c51752ab1816de311cb#dd118685db5da1aca3c22c51752ab1816de311cb"
+version = "0.2.5"
+source = "git+https://github.com/hyperlight-dev/hyperlight-js.git?rev=915608fbc30e922c7ed03aa08b05c3a3a5614f39#915608fbc30e922c7ed03aa08b05c3a3a5614f39"
 dependencies = [
  "anyhow",
  "cargo-hyperlight",
@@ -1757,27 +1792,35 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-js-runtime"
-version = "0.2.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight-js.git?rev=dd118685db5da1aca3c22c51752ab1816de311cb#dd118685db5da1aca3c22c51752ab1816de311cb"
+version = "0.2.5"
+source = "git+https://github.com/hyperlight-dev/hyperlight-js.git?rev=915608fbc30e922c7ed03aa08b05c3a3a5614f39#915608fbc30e922c7ed03aa08b05c3a3a5614f39"
 dependencies = [
  "anyhow",
  "base64",
  "bindgen",
- "chrono",
  "clap",
  "fn-traits",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "hex",
  "hmac",
- "hyperlight-common",
- "hyperlight-guest",
  "hyperlight-guest-bin",
  "rquickjs",
  "serde",
  "serde_json",
  "sha2",
- "spin",
+ "spin 0.12.0",
  "tracing",
+]
+
+[[package]]
+name = "hyperlight-libc"
+version = "0.15.0"
+source = "git+https://github.com/jsturtevant/hyperlight-1?rev=0fedd53253cc8b84f9d3e341bea181fd8db204d5#0fedd53253cc8b84f9d3e341bea181fd8db204d5"
+dependencies = [
+ "anyhow",
+ "bindgen",
+ "cc",
+ "glob",
 ]
 
 [[package]]
@@ -1853,7 +1896,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-wasm"
 version = "0.14.0"
-source = "git+https://github.com/jsturtevant/hyperlight-wasm?rev=13906096edc2e014220c11a040242070ce6dee90#13906096edc2e014220c11a040242070ce6dee90"
+source = "git+https://github.com/jsturtevant/hyperlight-wasm?rev=6618cabb1c52ad9469d6e2600c761a5b9060f772#6618cabb1c52ad9469d6e2600c761a5b9060f772"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1883,10 +1926,10 @@ dependencies = [
 [[package]]
 name = "hyperlight-wasm-macro"
 version = "0.14.0"
-source = "git+https://github.com/jsturtevant/hyperlight-wasm?rev=13906096edc2e014220c11a040242070ce6dee90#13906096edc2e014220c11a040242070ce6dee90"
+source = "git+https://github.com/jsturtevant/hyperlight-wasm?rev=6618cabb1c52ad9469d6e2600c761a5b9060f772#6618cabb1c52ad9469d6e2600c761a5b9060f772"
 dependencies = [
  "hyperlight-component-util",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -1895,7 +1938,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-wasm-runtime"
 version = "0.14.0"
-source = "git+https://github.com/jsturtevant/hyperlight-wasm?rev=13906096edc2e014220c11a040242070ce6dee90#13906096edc2e014220c11a040242070ce6dee90"
+source = "git+https://github.com/jsturtevant/hyperlight-wasm?rev=6618cabb1c52ad9469d6e2600c761a5b9060f772#6618cabb1c52ad9469d6e2600c761a5b9060f772"
 dependencies = [
  "cargo_metadata",
  "cc",
@@ -1905,9 +1948,9 @@ dependencies = [
  "hyperlight-guest",
  "hyperlight-guest-bin",
  "hyperlight-wasm-macro",
- "spin",
+ "spin 0.12.0",
  "tracing",
- "wasmtime 36.0.7",
+ "wasmtime 36.0.11",
 ]
 
 [[package]]
@@ -2102,7 +2145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2143,6 +2186,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -2210,12 +2262,12 @@ dependencies = [
 
 [[package]]
 name = "junction"
-version = "1.4.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
+checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
 dependencies = [
  "scopeguard",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2235,18 +2287,18 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "kvm-bindings"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b3c06ff73c7ce03e780887ec2389d62d2a2a9ddf471ab05c2ff69207cd3f3b4"
+checksum = "11cf0ca75d59e9d298647c59cf6c5286fa048120caa77972a7a504a0824d234f"
 dependencies = [
  "vmm-sys-util",
 ]
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "333f77a20344a448f3f70664918135fddeb804e938f28a99d685bd92926e0b19"
+checksum = "06ac372c120eb893b086d1a12027669cf2b478d1f71204021ffa7adf57948d63"
 dependencies = [
  "bitflags 2.13.0",
  "kvm-bindings",
@@ -2409,9 +2461,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.4"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cd3e9eb685089c784f5769b1197d348c7274bc20d4e1349650f63b91b6d0af"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
  "portable-atomic",
  "rapidhash",
@@ -2548,27 +2600,28 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_str_bytes"
-version = "7.1.1"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63eceb7b5d757011a87d08eb2123db15d87fb0c281f65d101ce30a1e96c3ad5c"
+checksum = "89284d0c2af7b0eb5e814798aa07265413c8fd72009f7fc82ea25a81fb287ce9"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "oxc_resolver"
-version = "11.19.1"
+version = "11.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5632fcd47d4fdaf7ef5ee150c7001fa8ed814ce38d1a073536a366dbfc239aad"
+checksum = "2b5400dea5053fe933683bcfc63cfd6025a9826748a9ecf2da37892d2993da57"
 dependencies = [
  "cfg-if",
  "compact_str",
+ "dashmap",
  "fast-glob",
  "indexmap",
  "json-strip-comments",
  "nodejs-built-in-modules",
  "once_cell",
- "papaya",
+ "percent-encoding",
  "rustc-hash",
  "rustix 1.1.4",
  "self_cell",
@@ -2578,7 +2631,6 @@ dependencies = [
  "simdutf8",
  "thiserror",
  "tracing",
- "url",
  "windows",
 ]
 
@@ -2590,16 +2642,6 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "papaya"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7"
-dependencies = [
- "equivalent",
- "seize",
 ]
 
 [[package]]
@@ -2633,9 +2675,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -2644,9 +2686,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
 dependencies = [
  "fastrand",
  "phf_shared",
@@ -2654,9 +2696,9 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -2667,9 +2709,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]
@@ -2806,13 +2848,13 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "36.0.7"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a078b4bdfd275fadeefc4f9ae3675ee5af302e69497da439956dd05257858970"
+checksum = "fae33db3d81aa92ead4ba06f7f9bbf32b2d8ff4132a00df5fa0913fd03dfa33c"
 dependencies = [
- "cranelift-bitset 0.123.7",
+ "cranelift-bitset 0.123.11",
  "log",
- "pulley-macros 36.0.7",
+ "pulley-macros 36.0.11",
  "wasmtime-internal-math",
 ]
 
@@ -2830,9 +2872,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "36.0.7"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dac91999883fd00b900eb5377be403c5cb8b93e10efcb571bf66454c2d9f231"
+checksum = "055100cf63f790c7bd02e606339916e1a403485358d4ae890ce912c102a9e80d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3159,9 +3201,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a"
+checksum = "c0688f8b0192998cca685adefdfad3483da295fa40a0ec406b4c14ecd729e858"
 dependencies = [
  "rquickjs-core",
  "rquickjs-macro",
@@ -3169,21 +3211,21 @@ dependencies = [
 
 [[package]]
 name = "rquickjs-core"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1"
+checksum = "2fee8c5383f0cfda3b980a80ca4520e726e09b593c59562f579daa51b6c20411"
 dependencies = [
  "async-lock",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "relative-path",
  "rquickjs-sys",
 ]
 
 [[package]]
 name = "rquickjs-macro"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7106215ff41a5677b104906a13e1a440b880f4b6362b5dc4f3978c267fad2b80"
+checksum = "04e6cf4b6e695b526cb430a6f445d3ccb9908696b99f1c1f8a1480af38bed5e6"
 dependencies = [
  "convert_case",
  "fnv",
@@ -3198,9 +3240,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs-sys"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83"
+checksum = "698077537c286a169de8693b216672bcef148bf2e2e112ebf50758c68e9afa09"
 dependencies = [
  "bindgen",
  "cc",
@@ -3286,7 +3328,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3391,16 +3433,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "seize"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3553,6 +3585,12 @@ name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
+name = "spin"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1527984ca054dfca79333baec451042863f485fbee01b7bf6d911de915cac865"
 dependencies = [
  "lock_api",
 ]
@@ -3646,7 +3684,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3803,17 +3841,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3887,9 +3914,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -4115,9 +4142,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.247.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80"
+checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
 dependencies = [
  "bitflags 2.13.0",
  "hashbrown 0.17.0",
@@ -4150,9 +4177,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "36.0.7"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b80d5ba38b9b00f60a0665e07dde38e91d884d4a78cd61d777c8cf081a1267c1"
+checksum = "319b720df5e1c49b5dbc916d28a386aad3f03ed96fa3cebe2c6270eb11b6baf3"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -4168,23 +4195,23 @@ dependencies = [
  "memfd",
  "object 0.37.3",
  "postcard",
- "pulley-interpreter 36.0.7",
+ "pulley-interpreter 36.0.11",
  "semver",
  "serde",
  "serde_derive",
  "smallvec",
  "target-lexicon",
  "wasmparser 0.236.1",
- "wasmtime-environ 36.0.7",
+ "wasmtime-environ 36.0.11",
  "wasmtime-internal-asm-macros",
- "wasmtime-internal-component-macro 36.0.7",
- "wasmtime-internal-component-util 36.0.7",
- "wasmtime-internal-cranelift 36.0.7",
+ "wasmtime-internal-component-macro 36.0.11",
+ "wasmtime-internal-component-util 36.0.11",
+ "wasmtime-internal-cranelift 36.0.11",
  "wasmtime-internal-math",
  "wasmtime-internal-slab",
- "wasmtime-internal-unwinder 36.0.7",
- "wasmtime-internal-versioned-export-macros 36.0.7",
- "wasmtime-internal-winch 36.0.7",
+ "wasmtime-internal-unwinder 36.0.11",
+ "wasmtime-internal-versioned-export-macros 36.0.11",
+ "wasmtime-internal-winch 36.0.11",
  "windows-sys 0.60.2",
 ]
 
@@ -4232,13 +4259,13 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "36.0.7"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44a45d60dea98308decb71a9f7bb35a629696d1fbf7127dbfde42cbc64b8fa33"
+checksum = "acc2633f356486b8c5917e2aad7aca2b5b54f0f674a8f384a166e34d48101893"
 dependencies = [
  "anyhow",
- "cranelift-bitset 0.123.7",
- "cranelift-entity 0.123.7",
+ "cranelift-bitset 0.123.11",
+ "cranelift-entity 0.123.11",
  "gimli 0.32.3",
  "indexmap",
  "log",
@@ -4252,7 +4279,7 @@ dependencies = [
  "wasm-encoder 0.236.1",
  "wasmparser 0.236.1",
  "wasmprinter 0.236.1",
- "wasmtime-internal-component-util 36.0.7",
+ "wasmtime-internal-component-util 36.0.11",
 ]
 
 [[package]]
@@ -4288,25 +4315,25 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "36.0.7"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd014b4001b6da03d79062d9ad5ec98fa62e34d50e30e46298545282cc2957e4"
+checksum = "f0e647efa7382e8cc8b668ee871af1da0f097d5f12ba2242ac865107c30996e8"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "36.0.7"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2942aa5d44b02061e0c6ab71b23090cf3b300b4519e3b80776ac38edde2e65"
+checksum = "13915309c8ac371ce8aaadf856aad7a7685e390fdf158df1d35c3b0b7a320c44"
 dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
  "syn",
- "wasmtime-internal-component-util 36.0.7",
- "wasmtime-internal-wit-bindgen 36.0.7",
+ "wasmtime-internal-component-util 36.0.11",
+ "wasmtime-internal-wit-bindgen 36.0.11",
  "wit-parser 0.236.1",
 ]
 
@@ -4327,9 +4354,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "36.0.7"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcb6f974fe739e98034b7e6ec6feb2ab399f4cde7207675f26138bd9a1d65720"
+checksum = "08935e3f35beb765593e42432b6f97fd6df16f1c9aa629a79137a04d30a168f4"
 
 [[package]]
 name = "wasmtime-internal-component-util"
@@ -4350,29 +4377,29 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "36.0.7"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4047020866a80aa943e41133e607020e17562126cf81533362275272098a22b1"
+checksum = "dd24355be6b01300639f3fd2e83dfbb75efc18a3d3386e955e87415c96fc105d"
 dependencies = [
  "anyhow",
  "cfg-if",
- "cranelift-codegen 0.123.7",
- "cranelift-control 0.123.7",
- "cranelift-entity 0.123.7",
- "cranelift-frontend 0.123.7",
- "cranelift-native 0.123.7",
+ "cranelift-codegen 0.123.11",
+ "cranelift-control 0.123.11",
+ "cranelift-entity 0.123.11",
+ "cranelift-frontend 0.123.11",
+ "cranelift-native 0.123.11",
  "gimli 0.32.3",
  "itertools 0.14.0",
  "log",
  "object 0.37.3",
- "pulley-interpreter 36.0.7",
+ "pulley-interpreter 36.0.11",
  "smallvec",
  "target-lexicon",
  "thiserror",
  "wasmparser 0.236.1",
- "wasmtime-environ 36.0.7",
+ "wasmtime-environ 36.0.11",
  "wasmtime-internal-math",
- "wasmtime-internal-versioned-export-macros 36.0.7",
+ "wasmtime-internal-versioned-export-macros 36.0.11",
 ]
 
 [[package]]
@@ -4441,24 +4468,24 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "36.0.7"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3a1f51a037ae2c048f0d76d36e27f0d22276295496c44f16a251f24690e003"
+checksum = "a28b0166bd79eb87e2e2e9d6ed7bc6c593428cadfd82cbc94fd113268c29d36a"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "36.0.7"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6171aac3d66e4d69e50080bb6bc5205de2283513984a4118a93cb66dc02994"
+checksum = "1c3295d1f1de2f3769b749a15e8f64341c38da6faa7fcd737ed485eb3fa40158"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "36.0.7"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd1bc1783391a02176fb687159b1779fc10b71d5350adf09c1f3aa8442a02cc"
+checksum = "a34055eb99cdff44ddd277e3b3baec670ef0302c847465c894f1118d4e7b1e3d"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4481,9 +4508,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "36.0.7"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8097e2c8ca02ed65d31dda111faa0888ffbf28dc3ee74355e283118a8d293eb0"
+checksum = "e69f8a29ae6fdf7218ae37f38b1cc9fe539344a17b7fffba203de3ee2194d605"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4503,19 +4530,19 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "36.0.7"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8cb36b61fbcff2c8bcd14f9f2651a6e52b019d0d329324620d7bc971b2b235"
+checksum = "c08a4d8a3501080d3707f845acfcd2fedec9bb91dad3fd9078b7a17e8c8a0884"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.123.7",
+ "cranelift-codegen 0.123.11",
  "gimli 0.32.3",
  "object 0.37.3",
  "target-lexicon",
  "wasmparser 0.236.1",
- "wasmtime-environ 36.0.7",
- "wasmtime-internal-cranelift 36.0.7",
- "winch-codegen 36.0.7",
+ "wasmtime-environ 36.0.11",
+ "wasmtime-internal-cranelift 36.0.11",
+ "winch-codegen 36.0.11",
 ]
 
 [[package]]
@@ -4537,9 +4564,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "36.0.7"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff555cfb71577028616d65c00221c7fe6eef45a9ebb96fc6d34d4a41fa1de191"
+checksum = "cc86f7cc67cafad52959bc1b91176d73e1ed6dbcc00c7a31b3c0a30ac32e881a"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -4676,7 +4703,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4687,21 +4714,21 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "36.0.7"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0989126b21d12c9923aa2de7ddbcf87db03037b24b7365041d9dd0095b69d8cb"
+checksum = "e33afb2737056d7162813a167fc53b8d986e725724a4e6c76ca9910952bb94b5"
 dependencies = [
  "anyhow",
- "cranelift-assembler-x64 0.123.7",
- "cranelift-codegen 0.123.7",
+ "cranelift-assembler-x64 0.123.11",
+ "cranelift-codegen 0.123.11",
  "gimli 0.32.3",
  "regalloc2 0.12.2",
  "smallvec",
  "target-lexicon",
  "thiserror",
  "wasmparser 0.236.1",
- "wasmtime-environ 36.0.7",
- "wasmtime-internal-cranelift 36.0.7",
+ "wasmtime-environ 36.0.11",
+ "wasmtime-internal-cranelift 36.0.11",
  "wasmtime-internal-math",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,6 +1004,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,6 +1050,37 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -1046,7 +1112,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1129,7 +1195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1200,6 +1266,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flatbuffers"
@@ -1382,6 +1454,17 @@ dependencies = [
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1625,11 +1708,13 @@ dependencies = [
 [[package]]
 name = "hyperlight-common"
 version = "0.15.0"
-source = "git+https://github.com/jsturtevant/hyperlight-1?rev=0fedd53253cc8b84f9d3e341bea181fd8db204d5#0fedd53253cc8b84f9d3e341bea181fd8db204d5"
+source = "git+https://github.com/jsturtevant/hyperlight-1?rev=2640a824b59d18e633e706e5639c7da30e7ad5fc#2640a824b59d18e633e706e5639c7da30e7ad5fc"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
  "bytemuck",
+ "bytes",
+ "fixedbitset",
  "flatbuffers",
  "log",
  "smallvec",
@@ -1642,7 +1727,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-component-macro"
 version = "0.15.0"
-source = "git+https://github.com/jsturtevant/hyperlight-1?rev=0fedd53253cc8b84f9d3e341bea181fd8db204d5#0fedd53253cc8b84f9d3e341bea181fd8db204d5"
+source = "git+https://github.com/jsturtevant/hyperlight-1?rev=2640a824b59d18e633e706e5639c7da30e7ad5fc#2640a824b59d18e633e706e5639c7da30e7ad5fc"
 dependencies = [
  "env_logger",
  "hyperlight-component-util",
@@ -1656,7 +1741,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-component-util"
 version = "0.15.0"
-source = "git+https://github.com/jsturtevant/hyperlight-1?rev=0fedd53253cc8b84f9d3e341bea181fd8db204d5#0fedd53253cc8b84f9d3e341bea181fd8db204d5"
+source = "git+https://github.com/jsturtevant/hyperlight-1?rev=2640a824b59d18e633e706e5639c7da30e7ad5fc#2640a824b59d18e633e706e5639c7da30e7ad5fc"
 dependencies = [
  "itertools 0.15.0",
  "prettyplease",
@@ -1670,7 +1755,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-guest"
 version = "0.15.0"
-source = "git+https://github.com/jsturtevant/hyperlight-1?rev=0fedd53253cc8b84f9d3e341bea181fd8db204d5#0fedd53253cc8b84f9d3e341bea181fd8db204d5"
+source = "git+https://github.com/jsturtevant/hyperlight-1?rev=2640a824b59d18e633e706e5639c7da30e7ad5fc#2640a824b59d18e633e706e5639c7da30e7ad5fc"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -1682,7 +1767,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-guest-bin"
 version = "0.15.0"
-source = "git+https://github.com/jsturtevant/hyperlight-1?rev=0fedd53253cc8b84f9d3e341bea181fd8db204d5#0fedd53253cc8b84f9d3e341bea181fd8db204d5"
+source = "git+https://github.com/jsturtevant/hyperlight-1?rev=2640a824b59d18e633e706e5639c7da30e7ad5fc#2640a824b59d18e633e706e5639c7da30e7ad5fc"
 dependencies = [
  "buddy_system_allocator",
  "flatbuffers",
@@ -1700,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-guest-macro"
 version = "0.15.0"
-source = "git+https://github.com/jsturtevant/hyperlight-1?rev=0fedd53253cc8b84f9d3e341bea181fd8db204d5#0fedd53253cc8b84f9d3e341bea181fd8db204d5"
+source = "git+https://github.com/jsturtevant/hyperlight-1?rev=2640a824b59d18e633e706e5639c7da30e7ad5fc#2640a824b59d18e633e706e5639c7da30e7ad5fc"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1711,7 +1796,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-guest-tracing"
 version = "0.15.0"
-source = "git+https://github.com/jsturtevant/hyperlight-1?rev=0fedd53253cc8b84f9d3e341bea181fd8db204d5#0fedd53253cc8b84f9d3e341bea181fd8db204d5"
+source = "git+https://github.com/jsturtevant/hyperlight-1?rev=2640a824b59d18e633e706e5639c7da30e7ad5fc#2640a824b59d18e633e706e5639c7da30e7ad5fc"
 dependencies = [
  "hyperlight-common",
  "spin 0.12.0",
@@ -1722,7 +1807,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-host"
 version = "0.15.0"
-source = "git+https://github.com/jsturtevant/hyperlight-1?rev=0fedd53253cc8b84f9d3e341bea181fd8db204d5#0fedd53253cc8b84f9d3e341bea181fd8db204d5"
+source = "git+https://github.com/jsturtevant/hyperlight-1?rev=2640a824b59d18e633e706e5639c7da30e7ad5fc#2640a824b59d18e633e706e5639c7da30e7ad5fc"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -1733,6 +1818,7 @@ dependencies = [
  "crossbeam-channel",
  "flatbuffers",
  "goblin",
+ "hex",
  "hyperlight-common",
  "kvm-bindings",
  "kvm-ioctls",
@@ -1742,10 +1828,14 @@ dependencies = [
  "metrics",
  "mshv-bindings",
  "mshv-ioctls",
+ "oci-spec",
  "page_size",
  "rand 0.10.1",
  "rust-embed",
+ "serde",
  "serde_json",
+ "sha2",
+ "tempfile",
  "termcolor",
  "thiserror",
  "tracing",
@@ -1815,7 +1905,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-libc"
 version = "0.15.0"
-source = "git+https://github.com/jsturtevant/hyperlight-1?rev=0fedd53253cc8b84f9d3e341bea181fd8db204d5#0fedd53253cc8b84f9d3e341bea181fd8db204d5"
+source = "git+https://github.com/jsturtevant/hyperlight-1?rev=2640a824b59d18e633e706e5639c7da30e7ad5fc#2640a824b59d18e633e706e5639c7da30e7ad5fc"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -1896,7 +1986,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-wasm"
 version = "0.14.0"
-source = "git+https://github.com/jsturtevant/hyperlight-wasm?rev=6618cabb1c52ad9469d6e2600c761a5b9060f772#6618cabb1c52ad9469d6e2600c761a5b9060f772"
+source = "git+https://github.com/jsturtevant/hyperlight-wasm?rev=447c5893fc916f1e9faf9aaac59afc45e6591d1f#447c5893fc916f1e9faf9aaac59afc45e6591d1f"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1926,7 +2016,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-wasm-macro"
 version = "0.14.0"
-source = "git+https://github.com/jsturtevant/hyperlight-wasm?rev=6618cabb1c52ad9469d6e2600c761a5b9060f772#6618cabb1c52ad9469d6e2600c761a5b9060f772"
+source = "git+https://github.com/jsturtevant/hyperlight-wasm?rev=447c5893fc916f1e9faf9aaac59afc45e6591d1f#447c5893fc916f1e9faf9aaac59afc45e6591d1f"
 dependencies = [
  "hyperlight-component-util",
  "itertools 0.15.0",
@@ -1938,7 +2028,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-wasm-runtime"
 version = "0.14.0"
-source = "git+https://github.com/jsturtevant/hyperlight-wasm?rev=6618cabb1c52ad9469d6e2600c761a5b9060f772#6618cabb1c52ad9469d6e2600c761a5b9060f772"
+source = "git+https://github.com/jsturtevant/hyperlight-wasm?rev=447c5893fc916f1e9faf9aaac59afc45e6591d1f#447c5893fc916f1e9faf9aaac59afc45e6591d1f"
 dependencies = [
  "cargo_metadata",
  "cc",
@@ -2145,7 +2235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2267,7 +2357,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
 dependencies = [
  "scopeguard",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2578,6 +2668,23 @@ dependencies = [
  "hashbrown 0.17.0",
  "indexmap",
  "memchr",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3da52b83ce3258fbf29f66ac784b279453c2ac3c22c5805371b921ede0d308"
+dependencies = [
+ "const_format",
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror",
 ]
 
 [[package]]
@@ -3328,7 +3435,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3614,6 +3721,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3684,7 +3809,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4703,7 +4828,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,20 +21,18 @@ hyperlight-sandbox = { path = "src/hyperlight_sandbox" }
 hyperlight-javascript-sandbox = { path = "src/javascript_sandbox" }
 hyperlight-wasm-sandbox = { path = "src/wasm_sandbox" }
 hyperlight-sandbox-pyo3-common = { path = "src/sdk/python/pyo3_common" }
-hyperlight-common = { version = "0.14.0", default-features = false }
-hyperlight-component-macro = { version = "0.14.0" }
-hyperlight-host = { version = "0.14.0", default-features = false, features = ["executable_heap"] }
-hyperlight-wasm = { git = "https://github.com/jsturtevant/hyperlight-wasm", rev = "13906096edc2e014220c11a040242070ce6dee90" } #branch util-compont-fixes
+hyperlight-common = { version = "0.15.0", default-features = false }
+hyperlight-component-macro = { version = "0.15.0" }
+hyperlight-host = { version = "0.15.0", default-features = false, features = ["executable_heap"] }
+# https://github.com/jsturtevant/hyperlight-wasm/tree/sandbox-component-bindgen-prs
+hyperlight-wasm = { git = "https://github.com/jsturtevant/hyperlight-wasm", rev = "6618cabb1c52ad9469d6e2600c761a5b9060f772" }
 pyo3 = { version = "0.29", features = ["extension-module"] }
 
-# hyperlight-wasm 0.13.1 (git) depends on hyperlight-* from the hyperlight-dev
-# GitHub org. Redirect those to the published 0.14.0 crates.io versions.
-[patch."https://github.com/hyperlight-dev/hyperlight"]
-hyperlight-common = { version = "0.14.0" }
-hyperlight-guest = { version = "=0.14.0" }
-hyperlight-guest-bin = { version = "=0.14.0" }
-hyperlight-host = { version = "0.14.0" }
-hyperlight-component-util = { git = "https://github.com/jsturtevant/hyperlight-1", rev="cdbed80af127b4d74e2633511cadb07bfea0160e",  package = "hyperlight-component-util" }
-
 [patch.crates-io]
-hyperlight-component-util = { git = "https://github.com/jsturtevant/hyperlight-1", rev="cdbed80af127b4d74e2633511cadb07bfea0160e", package = "hyperlight-component-util" }
+# https://github.com/jsturtevant/hyperlight-1/tree/sandbox-component-bindgen-prs
+hyperlight-common = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "0fedd53253cc8b84f9d3e341bea181fd8db204d5", package = "hyperlight-common" }
+hyperlight-component-macro = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "0fedd53253cc8b84f9d3e341bea181fd8db204d5", package = "hyperlight-component-macro" }
+hyperlight-component-util = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "0fedd53253cc8b84f9d3e341bea181fd8db204d5", package = "hyperlight-component-util" }
+hyperlight-guest = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "0fedd53253cc8b84f9d3e341bea181fd8db204d5", package = "hyperlight-guest" }
+hyperlight-guest-bin = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "0fedd53253cc8b84f9d3e341bea181fd8db204d5", package = "hyperlight-guest-bin" }
+hyperlight-host = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "0fedd53253cc8b84f9d3e341bea181fd8db204d5", package = "hyperlight-host" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,14 @@ hyperlight-common = { version = "0.15.0", default-features = false }
 hyperlight-component-macro = { version = "0.15.0" }
 hyperlight-host = { version = "0.15.0", default-features = false, features = ["executable_heap"] }
 # https://github.com/jsturtevant/hyperlight-wasm/tree/sandbox-component-bindgen-prs
-hyperlight-wasm = { git = "https://github.com/jsturtevant/hyperlight-wasm", rev = "6618cabb1c52ad9469d6e2600c761a5b9060f772" }
+hyperlight-wasm = { git = "https://github.com/jsturtevant/hyperlight-wasm", rev = "447c5893fc916f1e9faf9aaac59afc45e6591d1f" }
 pyo3 = { version = "0.29", features = ["extension-module"] }
 
 [patch.crates-io]
 # https://github.com/jsturtevant/hyperlight-1/tree/sandbox-component-bindgen-prs
-hyperlight-common = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "0fedd53253cc8b84f9d3e341bea181fd8db204d5", package = "hyperlight-common" }
-hyperlight-component-macro = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "0fedd53253cc8b84f9d3e341bea181fd8db204d5", package = "hyperlight-component-macro" }
-hyperlight-component-util = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "0fedd53253cc8b84f9d3e341bea181fd8db204d5", package = "hyperlight-component-util" }
-hyperlight-guest = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "0fedd53253cc8b84f9d3e341bea181fd8db204d5", package = "hyperlight-guest" }
-hyperlight-guest-bin = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "0fedd53253cc8b84f9d3e341bea181fd8db204d5", package = "hyperlight-guest-bin" }
-hyperlight-host = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "0fedd53253cc8b84f9d3e341bea181fd8db204d5", package = "hyperlight-host" }
+hyperlight-common = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "2640a824b59d18e633e706e5639c7da30e7ad5fc", package = "hyperlight-common" }
+hyperlight-component-macro = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "2640a824b59d18e633e706e5639c7da30e7ad5fc", package = "hyperlight-component-macro" }
+hyperlight-component-util = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "2640a824b59d18e633e706e5639c7da30e7ad5fc", package = "hyperlight-component-util" }
+hyperlight-guest = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "2640a824b59d18e633e706e5639c7da30e7ad5fc", package = "hyperlight-guest" }
+hyperlight-guest-bin = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "2640a824b59d18e633e706e5639c7da30e7ad5fc", package = "hyperlight-guest-bin" }
+hyperlight-host = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "2640a824b59d18e633e706e5639c7da30e7ad5fc", package = "hyperlight-host" }

--- a/src/javascript_sandbox/Cargo.toml
+++ b/src/javascript_sandbox/Cargo.toml
@@ -10,7 +10,7 @@ description = "Hyperlight JS guest for hyperlight-sandbox"
 hyperlight-sandbox.workspace = true
 anyhow = "1"
 url = "2"
-hyperlight-js = { git = "https://github.com/hyperlight-dev/hyperlight-js.git", rev = "dd118685db5da1aca3c22c51752ab1816de311cb" }
+hyperlight-js = { git = "https://github.com/hyperlight-dev/hyperlight-js.git", rev = "915608fbc30e922c7ed03aa08b05c3a3a5614f39" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/src/wasm_sandbox/Justfile
+++ b/src/wasm_sandbox/Justfile
@@ -14,13 +14,13 @@ ensure-tools:
     # (e.g. a stale wasmtime patch from the CI Cargo bin cache).
     cargo install hyperlight-wasm-aot --locked --force \
         --git https://github.com/jsturtevant/hyperlight-wasm \
-        --rev 13906096edc2e014220c11a040242070ce6dee90
+        --rev 6618cabb1c52ad9469d6e2600c761a5b9060f772
 
 [windows]
 ensure-tools:
     if (-not (Get-Command clang -ErrorAction SilentlyContinue)) { Write-Error 'clang not found — install with: winget install LLVM.LLVM'; exit 1 }; \
     if (-not (Get-Command wasm-tools -ErrorAction SilentlyContinue)) { cargo install wasm-tools --locked }; \
-    cargo install hyperlight-wasm-aot --locked --force --git https://github.com/jsturtevant/hyperlight-wasm --rev 13906096edc2e014220c11a040242070ce6dee90
+    cargo install hyperlight-wasm-aot --locked --force --git https://github.com/jsturtevant/hyperlight-wasm --rev 6618cabb1c52ad9469d6e2600c761a5b9060f772
 
 guest-build-wasm: ensure-tools
     cd {{repo-root}}/src/wasm_sandbox/guests/python && uv run componentize-py \

--- a/src/wasm_sandbox/Justfile
+++ b/src/wasm_sandbox/Justfile
@@ -14,13 +14,13 @@ ensure-tools:
     # (e.g. a stale wasmtime patch from the CI Cargo bin cache).
     cargo install hyperlight-wasm-aot --locked --force \
         --git https://github.com/jsturtevant/hyperlight-wasm \
-        --rev 6618cabb1c52ad9469d6e2600c761a5b9060f772
+        --rev 447c5893fc916f1e9faf9aaac59afc45e6591d1f
 
 [windows]
 ensure-tools:
     if (-not (Get-Command clang -ErrorAction SilentlyContinue)) { Write-Error 'clang not found — install with: winget install LLVM.LLVM'; exit 1 }; \
     if (-not (Get-Command wasm-tools -ErrorAction SilentlyContinue)) { cargo install wasm-tools --locked }; \
-    cargo install hyperlight-wasm-aot --locked --force --git https://github.com/jsturtevant/hyperlight-wasm --rev 6618cabb1c52ad9469d6e2600c761a5b9060f772
+    cargo install hyperlight-wasm-aot --locked --force --git https://github.com/jsturtevant/hyperlight-wasm --rev 447c5893fc916f1e9faf9aaac59afc45e6591d1f
 
 guest-build-wasm: ensure-tools
     cd {{repo-root}}/src/wasm_sandbox/guests/python && uv run componentize-py \

--- a/src/wasm_sandbox/src/lib.rs
+++ b/src/wasm_sandbox/src/lib.rs
@@ -125,13 +125,13 @@ impl bindings::root::component::RootImports for HostState {
         self
     }
 
-    type WasiFilesystemTypes = HostState;
-    fn wasi_filesystem_types(&mut self) -> &mut Self {
+    type WasiFilesystemTypesV020 = HostState;
+    fn wasi_filesystem_types_v0_2_0(&mut self) -> &mut Self {
         self
     }
 
-    type WasiHttpTypes = HostState;
-    fn wasi_http_types(&mut self) -> &mut Self {
+    type WasiHttpTypesV020 = HostState;
+    fn wasi_http_types_v0_2_0(&mut self) -> &mut Self {
         self
     }
 
@@ -197,22 +197,18 @@ impl bindings::root::component::RootImports for HostState {
 }
 
 impl bindings::hyperlight::sandbox::Tools for HostState {
-    fn dispatch(
-        &mut self,
-        name: String,
-        args_json: String,
-    ) -> Result<Result<String, String>, hyperlight_host::HyperlightError> {
+    fn dispatch(&mut self, name: String, args_json: String) -> Result<String, String> {
         let args: serde_json::Value = match serde_json::from_str(&args_json) {
             Ok(args) => args,
-            Err(error) => return Ok(Err(error.to_string())),
+            Err(error) => return Err(error.to_string()),
         };
-        Ok(match self.tools.dispatch(&name, args) {
+        match self.tools.dispatch(&name, args) {
             Ok(v) => match serde_json::to_string(&v) {
                 Ok(s) => Ok(s),
                 Err(e) => Err(format!("serialization failed: {e}")),
             },
             Err(e) => Err(e.to_string()),
-        })
+        }
     }
 }
 
@@ -270,7 +266,7 @@ impl WasmComponentSandbox {
     }
 
     fn run_impl(&mut self, code: &str) -> Result<ExecutionResult> {
-        use bindings::hyperlight::sandbox::Executor;
+        use bindings::hyperlight::sandbox::ExecutorExports;
 
         self.fs
             .lock()

--- a/src/wasm_sandbox/src/wasi_impl/cli.rs
+++ b/src/wasm_sandbox/src/wasi_impl/cli.rs
@@ -1,14 +1,12 @@
 //! CLI trait implementations: Environment, Exit, Stdin/Stdout/Stderr, Terminals.
 #![allow(unused_variables)]
 
-use hyperlight_host::HyperlightError;
-
 use crate::HostState;
 use crate::bindings::wasi;
 use crate::wasi_impl::resource::Resource;
 use crate::wasi_impl::types::stream::Stream;
 
-type HlResult<T> = Result<T, HyperlightError>;
+type HlResult<T> = T;
 
 // ---------------------------------------------------------------------------
 // CLI: Environment, Exit, Stdin/Stdout/Stderr
@@ -16,37 +14,35 @@ type HlResult<T> = Result<T, HyperlightError>;
 
 impl wasi::cli::Environment for HostState {
     fn get_environment(&mut self) -> HlResult<Vec<(String, String)>> {
-        Ok(Vec::new())
+        Vec::new()
     }
     fn get_arguments(&mut self) -> HlResult<Vec<String>> {
-        Ok(Vec::new())
+        Vec::new()
     }
     fn initial_cwd(&mut self) -> HlResult<Option<String>> {
-        Ok(None)
+        None
     }
 }
 
 impl wasi::cli::Exit for HostState {
-    fn exit(&mut self, _status: Result<(), ()>) -> HlResult<()> {
-        Ok(())
-    }
+    fn exit(&mut self, _status: Result<(), ()>) -> HlResult<()> {}
 }
 
 impl wasi::cli::Stdin<Resource<Stream>> for HostState {
     fn get_stdin(&mut self) -> HlResult<Resource<Stream>> {
-        Ok(Resource::new(Stream::new()))
+        Resource::new(Stream::new())
     }
 }
 
 impl wasi::cli::Stdout<Resource<Stream>> for HostState {
     fn get_stdout(&mut self) -> HlResult<Resource<Stream>> {
-        Ok(Resource::new(Stream::new()))
+        Resource::new(Stream::new())
     }
 }
 
 impl wasi::cli::Stderr<Resource<Stream>> for HostState {
     fn get_stderr(&mut self) -> HlResult<Resource<Stream>> {
-        Ok(Resource::new(Stream::new()))
+        Resource::new(Stream::new())
     }
 }
 
@@ -66,18 +62,18 @@ impl wasi::cli::TerminalOutput for HostState {}
 
 impl wasi::cli::TerminalStdin<u32> for HostState {
     fn get_terminal_stdin(&mut self) -> HlResult<Option<u32>> {
-        Ok(None)
+        None
     }
 }
 
 impl wasi::cli::TerminalStdout<u32> for HostState {
     fn get_terminal_stdout(&mut self) -> HlResult<Option<u32>> {
-        Ok(None)
+        None
     }
 }
 
 impl wasi::cli::TerminalStderr<u32> for HostState {
     fn get_terminal_stderr(&mut self) -> HlResult<Option<u32>> {
-        Ok(None)
+        None
     }
 }

--- a/src/wasm_sandbox/src/wasi_impl/clocks.rs
+++ b/src/wasm_sandbox/src/wasi_impl/clocks.rs
@@ -4,7 +4,6 @@
 use std::sync::LazyLock;
 use std::time::Duration;
 
-use hyperlight_host::HyperlightError;
 use wasi::clocks::{monotonic_clock, wall_clock};
 
 use crate::HostState;
@@ -12,7 +11,7 @@ use crate::bindings::wasi;
 use crate::wasi_impl::resource::Resource;
 use crate::wasi_impl::types::pollable::AnyPollable;
 
-type HlResult<T> = Result<T, HyperlightError>;
+type HlResult<T> = T;
 
 static EPOCH: LazyLock<std::time::Instant> = LazyLock::new(std::time::Instant::now);
 
@@ -22,28 +21,26 @@ fn now() -> u64 {
 
 impl wasi::clocks::MonotonicClock<Resource<AnyPollable>> for HostState {
     fn now(&mut self) -> HlResult<monotonic_clock::Instant> {
-        Ok(now())
+        now()
     }
     fn resolution(&mut self) -> HlResult<monotonic_clock::Duration> {
-        Ok(1)
+        1
     }
     fn subscribe_instant(
         &mut self,
         when: monotonic_clock::Instant,
     ) -> HlResult<Resource<AnyPollable>> {
-        Ok(Resource::new(AnyPollable::future(
-            tokio::time::sleep_until(
-                tokio::time::Instant::now() + Duration::from_nanos(when.saturating_sub(now())),
-            ),
+        Resource::new(AnyPollable::future(tokio::time::sleep_until(
+            tokio::time::Instant::now() + Duration::from_nanos(when.saturating_sub(now())),
         )))
     }
     fn subscribe_duration(
         &mut self,
         when: monotonic_clock::Duration,
     ) -> HlResult<Resource<AnyPollable>> {
-        Ok(Resource::new(AnyPollable::future(tokio::time::sleep(
+        Resource::new(AnyPollable::future(tokio::time::sleep(
             Duration::from_nanos(when),
-        ))))
+        )))
     }
 }
 
@@ -52,15 +49,15 @@ impl wasi::clocks::WallClock for HostState {
         let d = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default();
-        Ok(wall_clock::Datetime {
+        wall_clock::Datetime {
             seconds: d.as_secs(),
             nanoseconds: d.subsec_nanos(),
-        })
+        }
     }
     fn resolution(&mut self) -> HlResult<wall_clock::Datetime> {
-        Ok(wall_clock::Datetime {
+        wall_clock::Datetime {
             seconds: 0,
             nanoseconds: 1,
-        })
+        }
     }
 }

--- a/src/wasm_sandbox/src/wasi_impl/filesystem.rs
+++ b/src/wasm_sandbox/src/wasi_impl/filesystem.rs
@@ -2,7 +2,6 @@
 #![allow(unused_variables)]
 
 use hyperlight_common::resource::BorrowedResourceGuard;
-use hyperlight_host::HyperlightError;
 use hyperlight_sandbox::FsError;
 use wasi::clocks::wall_clock;
 use wasi::filesystem::types as fs_types;
@@ -12,7 +11,7 @@ use crate::bindings::wasi;
 use crate::wasi_impl::resource::Resource;
 use crate::wasi_impl::types::stream::Stream;
 
-type HlResult<T> = Result<T, HyperlightError>;
+type HlResult<T> = T;
 
 impl From<FsError> for fs_types::ErrorCode {
     fn from(e: FsError) -> Self {
@@ -38,7 +37,7 @@ impl fs_types::DirectoryEntryStream for HostState {
     ) -> HlResult<Result<Option<fs_types::DirectoryEntry>, fs_types::ErrorCode>> {
         let stream_id = *self_;
         let Ok(mut fs) = self.fs.lock() else {
-            return Ok(Err(fs_types::ErrorCode::Io));
+            return Err(fs_types::ErrorCode::Io);
         };
         if fs.has_dir_stream(stream_id) {
             match fs.read_dir_entry(stream_id) {
@@ -48,16 +47,16 @@ impl fs_types::DirectoryEntryStream for HostState {
                     } else {
                         fs_types::DescriptorType::RegularFile
                     };
-                    return Ok(Ok(Some(fs_types::DirectoryEntry {
+                    return Ok(Some(fs_types::DirectoryEntry {
                         r#type: dtype,
                         name,
-                    })));
+                    }));
                 }
-                Some(None) => return Ok(Ok(None)),
+                Some(None) => return Ok(None),
                 None => {}
             }
         }
-        Ok(Ok(None))
+        Ok(None)
     }
 }
 
@@ -77,12 +76,11 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
     ) -> HlResult<Result<Resource<Stream>, fs_types::ErrorCode>> {
         let fd = *self_;
         let Ok(mut fs) = self.fs.lock() else {
-            return Ok(Err(fs_types::ErrorCode::Io));
+            return Err(fs_types::ErrorCode::Io);
         };
-        Ok(fs
-            .create_read_stream(fd, offset)
+        fs.create_read_stream(fd, offset)
             .map(|stream_id| Resource::new(Stream::from_cap_fs(stream_id, self.fs.clone())))
-            .map_err(Into::into))
+            .map_err(Into::into)
     }
     fn write_via_stream(
         &mut self,
@@ -91,12 +89,11 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
     ) -> HlResult<Result<Resource<Stream>, fs_types::ErrorCode>> {
         let fd = *self_;
         let Ok(mut fs) = self.fs.lock() else {
-            return Ok(Err(fs_types::ErrorCode::Io));
+            return Err(fs_types::ErrorCode::Io);
         };
-        Ok(fs
-            .create_write_stream(fd, offset)
+        fs.create_write_stream(fd, offset)
             .map(|stream_id| Resource::new(Stream::from_cap_fs(stream_id, self.fs.clone())))
-            .map_err(Into::into))
+            .map_err(Into::into)
     }
     fn append_via_stream(
         &mut self,
@@ -104,12 +101,11 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
     ) -> HlResult<Result<Resource<Stream>, fs_types::ErrorCode>> {
         let fd = *self_;
         let Ok(mut fs) = self.fs.lock() else {
-            return Ok(Err(fs_types::ErrorCode::Io));
+            return Err(fs_types::ErrorCode::Io);
         };
-        Ok(fs
-            .create_append_stream(fd)
+        fs.create_append_stream(fd)
             .map(|stream_id| Resource::new(Stream::from_cap_fs(stream_id, self.fs.clone())))
-            .map_err(Into::into))
+            .map_err(Into::into)
     }
     fn advise(
         &mut self,
@@ -118,13 +114,13 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
         length: fs_types::Filesize,
         advice: fs_types::Advice,
     ) -> HlResult<Result<(), fs_types::ErrorCode>> {
-        Ok(Ok(()))
+        Ok(())
     }
     fn sync_data(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<(), fs_types::ErrorCode>> {
-        Ok(Err(fs_types::ErrorCode::Unsupported))
+        Err(fs_types::ErrorCode::Unsupported)
     }
     fn get_type(
         &mut self,
@@ -132,10 +128,9 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
     ) -> HlResult<Result<fs_types::DescriptorType, fs_types::ErrorCode>> {
         let fd = *self_;
         let Ok(fs) = self.fs.lock() else {
-            return Ok(Err(fs_types::ErrorCode::Io));
+            return Err(fs_types::ErrorCode::Io);
         };
-        Ok(fs
-            .get_type(fd)
+        fs.get_type(fd)
             .map(|t| match t {
                 hyperlight_sandbox::DescriptorType::Directory => {
                     fs_types::DescriptorType::Directory
@@ -144,14 +139,14 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
                     fs_types::DescriptorType::RegularFile
                 }
             })
-            .map_err(Into::into))
+            .map_err(Into::into)
     }
     fn set_size(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
         size: fs_types::Filesize,
     ) -> HlResult<Result<(), fs_types::ErrorCode>> {
-        Ok(Err(fs_types::ErrorCode::Unsupported))
+        Err(fs_types::ErrorCode::Unsupported)
     }
     fn set_times(
         &mut self,
@@ -159,7 +154,7 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
         data_access_timestamp: fs_types::NewTimestamp<wall_clock::Datetime>,
         data_modification_timestamp: fs_types::NewTimestamp<wall_clock::Datetime>,
     ) -> HlResult<Result<(), fs_types::ErrorCode>> {
-        Ok(Err(fs_types::ErrorCode::Unsupported))
+        Err(fs_types::ErrorCode::Unsupported)
     }
     fn read(
         &mut self,
@@ -169,9 +164,9 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
     ) -> HlResult<Result<(Vec<u8>, bool), fs_types::ErrorCode>> {
         let fd = *self_;
         let Ok(fs) = self.fs.lock() else {
-            return Ok(Err(fs_types::ErrorCode::Io));
+            return Err(fs_types::ErrorCode::Io);
         };
-        Ok(fs.read_file(fd, offset, length).map_err(Into::into))
+        fs.read_file(fd, offset, length).map_err(Into::into)
     }
     fn write(
         &mut self,
@@ -181,9 +176,9 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
     ) -> HlResult<Result<fs_types::Filesize, fs_types::ErrorCode>> {
         let fd = *self_;
         let Ok(mut fs) = self.fs.lock() else {
-            return Ok(Err(fs_types::ErrorCode::Io));
+            return Err(fs_types::ErrorCode::Io);
         };
-        Ok(fs.write_file(fd, offset, &buffer).map_err(Into::into))
+        fs.write_file(fd, offset, &buffer).map_err(Into::into)
     }
     fn read_directory(
         &mut self,
@@ -191,22 +186,22 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
     ) -> HlResult<Result<u32, fs_types::ErrorCode>> {
         let fd = *self_;
         let Ok(mut fs) = self.fs.lock() else {
-            return Ok(Err(fs_types::ErrorCode::Io));
+            return Err(fs_types::ErrorCode::Io);
         };
-        Ok(fs.create_dir_stream(fd).map_err(Into::into))
+        fs.create_dir_stream(fd).map_err(Into::into)
     }
     fn sync(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<(), fs_types::ErrorCode>> {
-        Ok(Err(fs_types::ErrorCode::Unsupported))
+        Err(fs_types::ErrorCode::Unsupported)
     }
     fn create_directory_at(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
         path: String,
     ) -> HlResult<Result<(), fs_types::ErrorCode>> {
-        Ok(Err(fs_types::ErrorCode::Unsupported))
+        Err(fs_types::ErrorCode::Unsupported)
     }
     fn stat(
         &mut self,
@@ -214,10 +209,9 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
     ) -> HlResult<Result<fs_types::DescriptorStat<wall_clock::Datetime>, fs_types::ErrorCode>> {
         let fd = *self_;
         let Ok(fs) = self.fs.lock() else {
-            return Ok(Err(fs_types::ErrorCode::Io));
+            return Err(fs_types::ErrorCode::Io);
         };
-        Ok(fs
-            .stat(fd)
+        fs.stat(fd)
             .map(|s| fs_types::DescriptorStat {
                 r#type: match s.descriptor_type {
                     hyperlight_sandbox::DescriptorType::Directory => {
@@ -233,21 +227,21 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
                 r#data_modification_timestamp: None,
                 r#status_change_timestamp: None,
             })
-            .map_err(Into::into))
+            .map_err(Into::into)
     }
     fn readlink_at(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
         path: String,
     ) -> HlResult<Result<String, fs_types::ErrorCode>> {
-        Ok(Err(fs_types::ErrorCode::NoEntry))
+        Err(fs_types::ErrorCode::NoEntry)
     }
     fn remove_directory_at(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
         path: String,
     ) -> HlResult<Result<(), fs_types::ErrorCode>> {
-        Ok(Err(fs_types::ErrorCode::Unsupported))
+        Err(fs_types::ErrorCode::Unsupported)
     }
     fn rename_at(
         &mut self,
@@ -256,7 +250,7 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
         new_descriptor: BorrowedResourceGuard<u32>,
         new_path: String,
     ) -> HlResult<Result<(), fs_types::ErrorCode>> {
-        Ok(Err(fs_types::ErrorCode::Unsupported))
+        Err(fs_types::ErrorCode::Unsupported)
     }
     fn symlink_at(
         &mut self,
@@ -264,27 +258,27 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
         old_path: String,
         new_path: String,
     ) -> HlResult<Result<(), fs_types::ErrorCode>> {
-        Ok(Err(fs_types::ErrorCode::Unsupported))
+        Err(fs_types::ErrorCode::Unsupported)
     }
     fn unlink_file_at(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
         path: String,
     ) -> HlResult<Result<(), fs_types::ErrorCode>> {
-        Ok(Err(fs_types::ErrorCode::Unsupported))
+        Err(fs_types::ErrorCode::Unsupported)
     }
     fn is_same_object(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
         other: BorrowedResourceGuard<u32>,
     ) -> HlResult<bool> {
-        Ok(false)
+        false
     }
     fn metadata_hash(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<fs_types::MetadataHashValue, fs_types::ErrorCode>> {
-        Ok(Err(fs_types::ErrorCode::Unsupported))
+        Err(fs_types::ErrorCode::Unsupported)
     }
     fn get_flags(
         &mut self,
@@ -292,10 +286,9 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
     ) -> HlResult<Result<fs_types::DescriptorFlags, fs_types::ErrorCode>> {
         let fd = *self_;
         let Ok(fs) = self.fs.lock() else {
-            return Ok(Err(fs_types::ErrorCode::Io));
+            return Err(fs_types::ErrorCode::Io);
         };
-        Ok(fs
-            .get_flags(fd)
+        fs.get_flags(fd)
             .map(|f| fs_types::DescriptorFlags {
                 r#read: f.read,
                 r#write: f.write,
@@ -304,7 +297,7 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
                 r#requested_write_sync: false,
                 r#mutate_directory: f.mutate_directory,
             })
-            .map_err(Into::into))
+            .map_err(Into::into)
     }
     fn stat_at(
         &mut self,
@@ -314,10 +307,9 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
     ) -> HlResult<Result<fs_types::DescriptorStat<wall_clock::Datetime>, fs_types::ErrorCode>> {
         let dir_fd = *self_;
         let Ok(fs) = self.fs.lock() else {
-            return Ok(Err(fs_types::ErrorCode::Io));
+            return Err(fs_types::ErrorCode::Io);
         };
-        Ok(fs
-            .stat_at(dir_fd, &path)
+        fs.stat_at(dir_fd, &path)
             .map(|s| fs_types::DescriptorStat {
                 r#type: match s.descriptor_type {
                     hyperlight_sandbox::DescriptorType::Directory => {
@@ -333,7 +325,7 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
                 r#data_modification_timestamp: None,
                 r#status_change_timestamp: None,
             })
-            .map_err(Into::into))
+            .map_err(Into::into)
     }
     fn set_times_at(
         &mut self,
@@ -343,7 +335,7 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
         data_access_timestamp: fs_types::NewTimestamp<wall_clock::Datetime>,
         data_modification_timestamp: fs_types::NewTimestamp<wall_clock::Datetime>,
     ) -> HlResult<Result<(), fs_types::ErrorCode>> {
-        Ok(Err(fs_types::ErrorCode::Unsupported))
+        Err(fs_types::ErrorCode::Unsupported)
     }
     fn link_at(
         &mut self,
@@ -353,7 +345,7 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
         new_descriptor: BorrowedResourceGuard<u32>,
         new_path: String,
     ) -> HlResult<Result<(), fs_types::ErrorCode>> {
-        Ok(Err(fs_types::ErrorCode::Unsupported))
+        Err(fs_types::ErrorCode::Unsupported)
     }
     fn open_at(
         &mut self,
@@ -365,7 +357,7 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
     ) -> HlResult<Result<u32, fs_types::ErrorCode>> {
         let dir_fd = *self_;
         let Ok(mut fs) = self.fs.lock() else {
-            return Ok(Err(fs_types::ErrorCode::Io));
+            return Err(fs_types::ErrorCode::Io);
         };
 
         let mut flags = hyperlight_sandbox::OpenFlags::empty();
@@ -375,7 +367,7 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
         if open_flags.r#truncate {
             flags |= hyperlight_sandbox::OpenFlags::TRUNCATE;
         }
-        Ok(fs.open_at(dir_fd, &path, flags).map_err(Into::into))
+        fs.open_at(dir_fd, &path, flags).map_err(Into::into)
     }
     fn metadata_hash_at(
         &mut self,
@@ -383,7 +375,7 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
         path_flags: fs_types::PathFlags,
         path: String,
     ) -> HlResult<Result<fs_types::MetadataHashValue, fs_types::ErrorCode>> {
-        Ok(Err(fs_types::ErrorCode::Unsupported))
+        Err(fs_types::ErrorCode::Unsupported)
     }
 }
 
@@ -395,19 +387,18 @@ impl
         &mut self,
         err: BorrowedResourceGuard<anyhow::Error>,
     ) -> HlResult<Option<fs_types::ErrorCode>> {
-        Ok(None)
+        None
     }
 }
 
 impl wasi::filesystem::Preopens<u32> for HostState {
     fn get_directories(&mut self) -> HlResult<Vec<(u32, String)>> {
         let Ok(fs) = self.fs.lock() else {
-            return Ok(vec![]);
+            return Vec::new();
         };
-        Ok(fs
-            .preopens()
+        fs.preopens()
             .into_iter()
             .map(|(fd, name)| (fd, name.to_string()))
-            .collect())
+            .collect()
     }
 }

--- a/src/wasm_sandbox/src/wasi_impl/http.rs
+++ b/src/wasm_sandbox/src/wasi_impl/http.rs
@@ -2,7 +2,6 @@
 #![allow(unused_variables)]
 
 use hyperlight_common::resource::BorrowedResourceGuard;
-use hyperlight_host::HyperlightError;
 use wasi::http::types as http_types;
 
 use crate::HostState;
@@ -22,7 +21,7 @@ use crate::wasi_impl::types::http_response_outparam::ResponseOutparam;
 use crate::wasi_impl::types::pollable::AnyPollable;
 use crate::wasi_impl::types::stream::Stream;
 
-type HlResult<T> = Result<T, HyperlightError>;
+type HlResult<T> = T;
 
 // ---------------------------------------------------------------------------
 // Fields (Headers/Trailers)
@@ -49,23 +48,23 @@ impl http_types::Fields for HostState {
         &mut self,
         entries: Vec<(String, Vec<u8>)>,
     ) -> HlResult<Result<Resource<Headers>, http_types::HeaderError>> {
-        Ok(Headers::from_list(entries)
+        Headers::from_list(entries)
             .map(Resource::new)
-            .map_err(Into::into))
+            .map_err(Into::into)
     }
     fn get(
         &mut self,
         self_: BorrowedResourceGuard<Resource<Headers>>,
         name: String,
     ) -> HlResult<Vec<Vec<u8>>> {
-        Ok(self_.read().block_on().get(name).unwrap_or_default())
+        self_.read().block_on().get(name).unwrap_or_default()
     }
     fn has(
         &mut self,
         self_: BorrowedResourceGuard<Resource<Headers>>,
         name: String,
     ) -> HlResult<bool> {
-        Ok(self_.read().block_on().has(name))
+        self_.read().block_on().has(name)
     }
     fn set(
         &mut self,
@@ -73,18 +72,18 @@ impl http_types::Fields for HostState {
         name: String,
         value: Vec<Vec<u8>>,
     ) -> HlResult<Result<(), http_types::HeaderError>> {
-        Ok(self_
+        self_
             .write()
             .block_on()
             .set(name, value)
-            .map_err(Into::into))
+            .map_err(Into::into)
     }
     fn delete(
         &mut self,
         self_: BorrowedResourceGuard<Resource<Headers>>,
         name: String,
     ) -> HlResult<Result<(), http_types::HeaderError>> {
-        Ok(self_.write().block_on().delete(name).map_err(Into::into))
+        self_.write().block_on().delete(name).map_err(Into::into)
     }
     fn append(
         &mut self,
@@ -92,23 +91,23 @@ impl http_types::Fields for HostState {
         name: String,
         value: Vec<u8>,
     ) -> HlResult<Result<(), http_types::HeaderError>> {
-        Ok(self_
+        self_
             .write()
             .block_on()
             .append(name, value)
-            .map_err(Into::into))
+            .map_err(Into::into)
     }
     fn entries(
         &mut self,
         self_: BorrowedResourceGuard<Resource<Headers>>,
     ) -> HlResult<Vec<(String, Vec<u8>)>> {
-        Ok(self_.read().block_on().entries())
+        self_.read().block_on().entries()
     }
     fn clone(
         &mut self,
         self_: BorrowedResourceGuard<Resource<Headers>>,
     ) -> HlResult<Resource<Headers>> {
-        Ok(self_.clone())
+        self_.clone()
     }
 }
 
@@ -122,31 +121,31 @@ impl http_types::IncomingRequest<Resource<Headers>, Resource<IncomingBody>> for 
         &mut self,
         self_: BorrowedResourceGuard<Resource<IncomingRequest>>,
     ) -> HlResult<http_types::Method> {
-        Ok(self_.read().block_on().method.clone())
+        self_.read().block_on().method.clone()
     }
     fn path_with_query(
         &mut self,
         self_: BorrowedResourceGuard<Resource<IncomingRequest>>,
     ) -> HlResult<Option<String>> {
-        Ok(self_.read().block_on().path_with_query.clone())
+        self_.read().block_on().path_with_query.clone()
     }
     fn scheme(
         &mut self,
         self_: BorrowedResourceGuard<Resource<IncomingRequest>>,
     ) -> HlResult<Option<http_types::Scheme>> {
-        Ok(self_.read().block_on().scheme.clone())
+        self_.read().block_on().scheme.clone()
     }
     fn authority(
         &mut self,
         self_: BorrowedResourceGuard<Resource<IncomingRequest>>,
     ) -> HlResult<Option<String>> {
-        Ok(self_.read().block_on().authority.clone())
+        self_.read().block_on().authority.clone()
     }
     fn headers(
         &mut self,
         self_: BorrowedResourceGuard<Resource<IncomingRequest>>,
     ) -> HlResult<Resource<Headers>> {
-        Ok(self_.read().block_on().headers.clone())
+        self_.read().block_on().headers.clone()
     }
     fn consume(
         &mut self,
@@ -154,10 +153,10 @@ impl http_types::IncomingRequest<Resource<Headers>, Resource<IncomingBody>> for 
     ) -> HlResult<Result<Resource<IncomingBody>, ()>> {
         let mut guard = self_.write().block_on();
         if guard.body_taken {
-            return Ok(Err(()));
+            return Err(());
         }
         guard.body_taken = true;
-        Ok(Ok(guard.body.clone()))
+        Ok(guard.body.clone())
     }
 }
 
@@ -175,13 +174,13 @@ impl http_types::OutgoingRequest<Resource<Headers>, Resource<OutgoingBody>> for 
         self_: BorrowedResourceGuard<Resource<OutgoingRequest>>,
     ) -> HlResult<Result<Resource<OutgoingBody>, ()>> {
         let mut guard = self_.write().block_on();
-        Ok(guard.take_body().ok_or(()))
+        guard.take_body().ok_or(())
     }
     fn method(
         &mut self,
         self_: BorrowedResourceGuard<Resource<OutgoingRequest>>,
     ) -> HlResult<http_types::Method> {
-        Ok(self_.read().block_on().method.clone())
+        self_.read().block_on().method.clone()
     }
     fn set_method(
         &mut self,
@@ -189,13 +188,13 @@ impl http_types::OutgoingRequest<Resource<Headers>, Resource<OutgoingBody>> for 
         method: http_types::Method,
     ) -> HlResult<Result<(), ()>> {
         self_.write().block_on().method = method;
-        Ok(Ok(()))
+        Ok(())
     }
     fn path_with_query(
         &mut self,
         self_: BorrowedResourceGuard<Resource<OutgoingRequest>>,
     ) -> HlResult<Option<String>> {
-        Ok(self_.read().block_on().path_with_query.clone())
+        self_.read().block_on().path_with_query.clone()
     }
     fn set_path_with_query(
         &mut self,
@@ -203,13 +202,13 @@ impl http_types::OutgoingRequest<Resource<Headers>, Resource<OutgoingBody>> for 
         path_with_query: Option<String>,
     ) -> HlResult<Result<(), ()>> {
         self_.write().block_on().path_with_query = path_with_query;
-        Ok(Ok(()))
+        Ok(())
     }
     fn scheme(
         &mut self,
         self_: BorrowedResourceGuard<Resource<OutgoingRequest>>,
     ) -> HlResult<Option<http_types::Scheme>> {
-        Ok(self_.read().block_on().scheme.clone())
+        self_.read().block_on().scheme.clone()
     }
     fn set_scheme(
         &mut self,
@@ -217,13 +216,13 @@ impl http_types::OutgoingRequest<Resource<Headers>, Resource<OutgoingBody>> for 
         scheme: Option<http_types::Scheme>,
     ) -> HlResult<Result<(), ()>> {
         self_.write().block_on().scheme = scheme;
-        Ok(Ok(()))
+        Ok(())
     }
     fn authority(
         &mut self,
         self_: BorrowedResourceGuard<Resource<OutgoingRequest>>,
     ) -> HlResult<Option<String>> {
-        Ok(self_.read().block_on().authority.clone())
+        self_.read().block_on().authority.clone()
     }
     fn set_authority(
         &mut self,
@@ -231,13 +230,13 @@ impl http_types::OutgoingRequest<Resource<Headers>, Resource<OutgoingBody>> for 
         authority: Option<String>,
     ) -> HlResult<Result<(), ()>> {
         self_.write().block_on().authority = authority;
-        Ok(Ok(()))
+        Ok(())
     }
     fn headers(
         &mut self,
         self_: BorrowedResourceGuard<Resource<OutgoingRequest>>,
     ) -> HlResult<Resource<Headers>> {
-        Ok(self_.read().block_on().headers.clone())
+        self_.read().block_on().headers.clone()
     }
 }
 
@@ -258,12 +257,12 @@ impl http_types::RequestOptions<u64> for HostState {
         &mut self,
         self_: BorrowedResourceGuard<Resource<RequestOptions>>,
     ) -> HlResult<Option<u64>> {
-        Ok(self_
+        self_
             .read()
             .block_on()
             .connect_timeout
             .as_ref()
-            .map(as_u64_nanos_saturating))
+            .map(as_u64_nanos_saturating)
     }
     fn set_connect_timeout(
         &mut self,
@@ -271,18 +270,18 @@ impl http_types::RequestOptions<u64> for HostState {
         duration: Option<u64>,
     ) -> HlResult<Result<(), ()>> {
         self_.write().block_on().connect_timeout = duration.map(std::time::Duration::from_nanos);
-        Ok(Ok(()))
+        Ok(())
     }
     fn first_byte_timeout(
         &mut self,
         self_: BorrowedResourceGuard<Resource<RequestOptions>>,
     ) -> HlResult<Option<u64>> {
-        Ok(self_
+        self_
             .read()
             .block_on()
             .first_byte_timeout
             .as_ref()
-            .map(as_u64_nanos_saturating))
+            .map(as_u64_nanos_saturating)
     }
     fn set_first_byte_timeout(
         &mut self,
@@ -290,18 +289,18 @@ impl http_types::RequestOptions<u64> for HostState {
         duration: Option<u64>,
     ) -> HlResult<Result<(), ()>> {
         self_.write().block_on().first_byte_timeout = duration.map(std::time::Duration::from_nanos);
-        Ok(Ok(()))
+        Ok(())
     }
     fn between_bytes_timeout(
         &mut self,
         self_: BorrowedResourceGuard<Resource<RequestOptions>>,
     ) -> HlResult<Option<u64>> {
-        Ok(self_
+        self_
             .read()
             .block_on()
             .between_bytes_timeout
             .as_ref()
-            .map(as_u64_nanos_saturating))
+            .map(as_u64_nanos_saturating)
     }
     fn set_between_bytes_timeout(
         &mut self,
@@ -310,7 +309,7 @@ impl http_types::RequestOptions<u64> for HostState {
     ) -> HlResult<Result<(), ()>> {
         self_.write().block_on().between_bytes_timeout =
             duration.map(std::time::Duration::from_nanos);
-        Ok(Ok(()))
+        Ok(())
     }
 }
 
@@ -326,7 +325,6 @@ impl http_types::ResponseOutparam<Resource<OutgoingResponse>> for HostState {
         response: Result<Resource<OutgoingResponse>, http_types::ErrorCode>,
     ) -> HlResult<()> {
         param.write().block_on().response = Some(response);
-        Ok(())
     }
 }
 
@@ -340,13 +338,13 @@ impl http_types::IncomingResponse<Resource<Headers>, Resource<IncomingBody>> for
         &mut self,
         self_: BorrowedResourceGuard<Resource<IncomingResponse>>,
     ) -> HlResult<u16> {
-        Ok(self_.read().block_on().status)
+        self_.read().block_on().status
     }
     fn headers(
         &mut self,
         self_: BorrowedResourceGuard<Resource<IncomingResponse>>,
     ) -> HlResult<Resource<Headers>> {
-        Ok(self_.read().block_on().headers.clone())
+        self_.read().block_on().headers.clone()
     }
     fn consume(
         &mut self,
@@ -354,10 +352,10 @@ impl http_types::IncomingResponse<Resource<Headers>, Resource<IncomingBody>> for
     ) -> HlResult<Result<Resource<IncomingBody>, ()>> {
         let mut guard = self_.write().block_on();
         if guard.body_taken {
-            return Ok(Err(()));
+            return Err(());
         }
         guard.body_taken = true;
-        Ok(Ok(guard.body.clone()))
+        Ok(guard.body.clone())
     }
 }
 
@@ -373,13 +371,13 @@ impl http_types::IncomingBody<Resource<FutureHeaders>, Resource<Stream>> for Hos
     ) -> HlResult<Result<Resource<Stream>, ()>> {
         let mut guard = self_.write().block_on();
         if guard.stream_taken {
-            return Ok(Err(()));
+            return Err(());
         }
         guard.stream_taken = true;
-        Ok(Ok(guard.stream.clone()))
+        Ok(guard.stream.clone())
     }
     fn finish(&mut self, this: Resource<IncomingBody>) -> HlResult<Resource<FutureHeaders>> {
-        Ok(this.read().block_on().trailers.clone())
+        this.read().block_on().trailers.clone()
     }
 }
 
@@ -395,10 +393,10 @@ impl http_types::OutgoingBody<Resource<Headers>, Resource<Stream>> for HostState
     ) -> HlResult<Result<Resource<Stream>, ()>> {
         let mut guard = self_.write().block_on();
         if guard.body_taken {
-            return Ok(Err(()));
+            return Err(());
         }
         guard.body_taken = true;
-        Ok(Ok(guard.body.clone()))
+        Ok(guard.body.clone())
     }
     fn finish(
         &mut self,
@@ -409,7 +407,7 @@ impl http_types::OutgoingBody<Resource<Headers>, Resource<Stream>> for HostState
         let (_, written) = guard.body.write().block_on().close();
         guard.finished = true;
         guard.trailers = trailers.unwrap_or_default();
-        Ok(Ok(()))
+        Ok(())
     }
 }
 
@@ -426,7 +424,7 @@ impl http_types::OutgoingResponse<Resource<Headers>, Resource<OutgoingBody>> for
         &mut self,
         self_: BorrowedResourceGuard<Resource<OutgoingResponse>>,
     ) -> HlResult<u16> {
-        Ok(self_.read().block_on().status_code)
+        self_.read().block_on().status_code
     }
     fn set_status_code(
         &mut self,
@@ -434,20 +432,20 @@ impl http_types::OutgoingResponse<Resource<Headers>, Resource<OutgoingBody>> for
         status_code: u16,
     ) -> HlResult<Result<(), ()>> {
         self_.write().block_on().status_code = status_code;
-        Ok(Ok(()))
+        Ok(())
     }
     fn headers(
         &mut self,
         self_: BorrowedResourceGuard<Resource<OutgoingResponse>>,
     ) -> HlResult<Resource<Headers>> {
-        Ok(self_.read().block_on().headers.clone())
+        self_.read().block_on().headers.clone()
     }
     fn body(
         &mut self,
         self_: BorrowedResourceGuard<Resource<OutgoingResponse>>,
     ) -> HlResult<Result<Resource<OutgoingBody>, ()>> {
         let mut guard = self_.write().block_on();
-        Ok(guard.take_body().ok_or(()))
+        guard.take_body().ok_or(())
     }
 }
 
@@ -461,20 +459,20 @@ impl http_types::FutureTrailers<Resource<Headers>, Resource<AnyPollable>> for Ho
         &mut self,
         self_: BorrowedResourceGuard<Resource<FutureHeaders>>,
     ) -> HlResult<Resource<AnyPollable>> {
-        Ok(self_.poll(|r| r.is_ready()))
+        self_.poll(|r| r.is_ready())
     }
     fn get(
         &mut self,
         self_: BorrowedResourceGuard<Resource<FutureHeaders>>,
     ) -> HlResult<Option<Result<Result<Option<Resource<Headers>>, http_types::ErrorCode>, ()>>>
     {
-        Ok(match self_.write().block_on().get() {
+        match self_.write().block_on().get() {
             Some(Ok(Ok(headers))) if headers.read().block_on().is_empty() => Some(Ok(Ok(None))),
             Some(Ok(Ok(headers))) => Some(Ok(Ok(Some(headers)))),
             Some(Ok(Err(e))) => Some(Ok(Err(e))),
             Some(Err(())) => Some(Err(())),
             None => None,
-        })
+        }
     }
 }
 
@@ -490,14 +488,14 @@ impl http_types::FutureIncomingResponse<Resource<IncomingResponse>, Resource<Any
         &mut self,
         self_: BorrowedResourceGuard<Resource<FutureIncomingResponse>>,
     ) -> HlResult<Resource<AnyPollable>> {
-        Ok(self_.poll(|r| r.is_ready()))
+        self_.poll(|r| r.is_ready())
     }
     fn get(
         &mut self,
         self_: BorrowedResourceGuard<Resource<FutureIncomingResponse>>,
     ) -> HlResult<Option<Result<Result<Resource<IncomingResponse>, http_types::ErrorCode>, ()>>>
     {
-        Ok(self_.write().block_on().get())
+        self_.write().block_on().get()
     }
 }
 
@@ -513,8 +511,6 @@ impl
         &mut self,
         err: BorrowedResourceGuard<anyhow::Error>,
     ) -> HlResult<Option<http_types::ErrorCode>> {
-        Ok(Some(http_types::ErrorCode::InternalError(Some(
-            err.to_string(),
-        ))))
+        Some(http_types::ErrorCode::InternalError(Some(err.to_string())))
     }
 }

--- a/src/wasm_sandbox/src/wasi_impl/http_handler.rs
+++ b/src/wasm_sandbox/src/wasi_impl/http_handler.rs
@@ -6,7 +6,6 @@
 
 use std::sync::atomic::Ordering;
 
-use hyperlight_host::HyperlightError;
 use hyperlight_sandbox::http as sandbox_http;
 use wasi::http::types::ErrorCode;
 
@@ -21,7 +20,7 @@ use crate::wasi_impl::types::http_outgoing_request::OutgoingRequest;
 use crate::wasi_impl::types::http_request_options::RequestOptions;
 use crate::wasi_impl::types::stream::Stream;
 
-type HlResult<T> = Result<T, HyperlightError>;
+type HlResult<T> = T;
 
 fn wasi_method_to_http_method(
     method: &wasi::http::types::Method,
@@ -58,34 +57,40 @@ impl
         // Network permission check — always performed.
         let authority = match request_data.authority {
             Some(ref a) => a,
-            None => return Ok(Err(ErrorCode::HTTPRequestDenied)),
+            None => return Err(ErrorCode::HTTPRequestDenied),
         };
 
         let http_method = match wasi_method_to_http_method(&request_data.method) {
             Ok(m) => m,
-            Err(e) => return Ok(Err(e)),
+            Err(e) => return Err(e),
         };
 
         let scheme_str = match &request_data.scheme {
             Some(wasi::http::types::Scheme::HTTP) => "http",
             Some(wasi::http::types::Scheme::HTTPS) => "https",
             Some(wasi::http::types::Scheme::Other(_)) => {
-                return Ok(Err(ErrorCode::InternalError(Some(
+                return Err(ErrorCode::InternalError(Some(
                     "only http and https schemes are supported".to_string(),
-                ))));
+                )));
             }
             None => "https",
         };
         let path = request_data.path_with_query.as_deref().unwrap_or("/");
-        let request_url = url::Url::parse(&format!("{scheme_str}://{authority}{path}"))
-            .map_err(|e| HyperlightError::Error(format!("invalid request URL: {e}")))?;
+        let request_url = match url::Url::parse(&format!("{scheme_str}://{authority}{path}")) {
+            Ok(url) => url,
+            Err(e) => {
+                return Err(ErrorCode::InternalError(Some(format!(
+                    "invalid request URL: {e}"
+                ))));
+            }
+        };
 
         {
             let Ok(network) = self.network.lock() else {
-                return Ok(Err(ErrorCode::HTTPRequestDenied));
+                return Err(ErrorCode::HTTPRequestDenied);
             };
             if !network.is_allowed(&request_url, &http_method) {
-                return Ok(Err(ErrorCode::HTTPRequestDenied));
+                return Err(ErrorCode::HTTPRequestDenied);
             }
         }
 
@@ -93,9 +98,9 @@ impl
         let active = self.active_requests.fetch_add(1, Ordering::SeqCst);
         if active >= sandbox_http::MAX_CONCURRENT_REQUESTS {
             self.active_requests.fetch_sub(1, Ordering::SeqCst);
-            return Ok(Err(ErrorCode::InternalError(Some(
+            return Err(ErrorCode::InternalError(Some(
                 "too many concurrent HTTP requests".to_string(),
-            ))));
+            )));
         }
         let active_requests = self.active_requests.clone();
 
@@ -197,6 +202,6 @@ impl
         }
         .spawn();
 
-        Ok(Ok(future_response))
+        Ok(future_response)
     }
 }

--- a/src/wasm_sandbox/src/wasi_impl/http_handler.rs
+++ b/src/wasm_sandbox/src/wasi_impl/http_handler.rs
@@ -60,10 +60,7 @@ impl
             None => return Err(ErrorCode::HTTPRequestDenied),
         };
 
-        let http_method = match wasi_method_to_http_method(&request_data.method) {
-            Ok(m) => m,
-            Err(e) => return Err(e),
-        };
+        let http_method = wasi_method_to_http_method(&request_data.method)?;
 
         let scheme_str = match &request_data.scheme {
             Some(wasi::http::types::Scheme::HTTP) => "http",

--- a/src/wasm_sandbox/src/wasi_impl/io.rs
+++ b/src/wasm_sandbox/src/wasi_impl/io.rs
@@ -2,7 +2,6 @@
 #![allow(unused_variables)]
 
 use hyperlight_common::resource::BorrowedResourceGuard;
-use hyperlight_host::HyperlightError;
 use wasi::io::streams;
 
 use crate::HostState;
@@ -11,7 +10,7 @@ use crate::wasi_impl::resource::{BlockOn, Resource};
 use crate::wasi_impl::types::pollable::AnyPollable;
 use crate::wasi_impl::types::stream::Stream;
 
-type HlResult<T> = Result<T, HyperlightError>;
+type HlResult<T> = T;
 
 /// Maximum byte count for a single write-zeroes or random-bytes allocation.
 /// 16 MiB is generous for any legitimate use while preventing host OOM.
@@ -24,7 +23,7 @@ const MAX_ALLOC_BYTES: u64 = 16 * 1024 * 1024;
 impl wasi::io::error::Error for HostState {
     type T = anyhow::Error;
     fn to_debug_string(&mut self, self_: BorrowedResourceGuard<anyhow::Error>) -> HlResult<String> {
-        Ok(self_.to_string())
+        self_.to_string()
     }
 }
 
@@ -37,11 +36,10 @@ impl wasi::io::Error for HostState {}
 impl wasi::io::poll::Pollable for HostState {
     type T = Resource<AnyPollable>;
     fn ready(&mut self, self_: BorrowedResourceGuard<Resource<AnyPollable>>) -> HlResult<bool> {
-        Ok(self_.write().block_on().ready().block_on())
+        self_.write().block_on().ready().block_on()
     }
     fn block(&mut self, self_: BorrowedResourceGuard<Resource<AnyPollable>>) -> HlResult<()> {
         self_.write().block_on().block().block_on();
-        Ok(())
     }
 }
 
@@ -58,7 +56,7 @@ impl wasi::io::Poll for HostState {
             .map(|p| p.write().block_on())
             .collect::<Vec<_>>();
 
-        Ok(poll_fn(move |cx| {
+        poll_fn(move |cx| {
             for (i, pollable) in guards.iter_mut().enumerate() {
                 if let Poll::Ready(true) = pollable.poll(cx) {
                     return Poll::Ready(vec![i as u32]);
@@ -66,7 +64,7 @@ impl wasi::io::Poll for HostState {
             }
             Poll::Pending
         })
-        .block_on())
+        .block_on()
     }
 }
 
@@ -82,9 +80,9 @@ impl streams::InputStream<anyhow::Error, Resource<AnyPollable>> for HostState {
         len: u64,
     ) -> HlResult<Result<Vec<u8>, streams::StreamError<anyhow::Error>>> {
         let mut guard = self_.write().block_on();
-        Ok(guard
+        guard
             .read(len as usize)
-            .map_err(|_| streams::StreamError::Closed))
+            .map_err(|_| streams::StreamError::Closed)
     }
     fn blocking_read(
         &mut self,
@@ -92,9 +90,9 @@ impl streams::InputStream<anyhow::Error, Resource<AnyPollable>> for HostState {
         len: u64,
     ) -> HlResult<Result<Vec<u8>, streams::StreamError<anyhow::Error>>> {
         let mut guard = self_.write_wait_until(Stream::readable).block_on();
-        Ok(guard
+        guard
             .read(len as usize)
-            .map_err(|_| streams::StreamError::Closed))
+            .map_err(|_| streams::StreamError::Closed)
     }
     fn skip(
         &mut self,
@@ -102,10 +100,10 @@ impl streams::InputStream<anyhow::Error, Resource<AnyPollable>> for HostState {
         len: u64,
     ) -> HlResult<Result<u64, streams::StreamError<anyhow::Error>>> {
         let mut guard = self_.write().block_on();
-        Ok(guard
+        guard
             .read(len as usize)
             .map(|d| d.len() as u64)
-            .map_err(|_| streams::StreamError::Closed))
+            .map_err(|_| streams::StreamError::Closed)
     }
     fn blocking_skip(
         &mut self,
@@ -113,16 +111,16 @@ impl streams::InputStream<anyhow::Error, Resource<AnyPollable>> for HostState {
         len: u64,
     ) -> HlResult<Result<u64, streams::StreamError<anyhow::Error>>> {
         let mut guard = self_.write_wait_until(Stream::readable).block_on();
-        Ok(guard
+        guard
             .read(len as usize)
             .map(|d| d.len() as u64)
-            .map_err(|_| streams::StreamError::Closed))
+            .map_err(|_| streams::StreamError::Closed)
     }
     fn subscribe(
         &mut self,
         self_: BorrowedResourceGuard<Resource<Stream>>,
     ) -> HlResult<Resource<AnyPollable>> {
-        Ok(self_.poll(|b| b.readable()))
+        self_.poll(|b| b.readable())
     }
 }
 
@@ -133,9 +131,9 @@ impl streams::OutputStream<anyhow::Error, Resource<Stream>, Resource<AnyPollable
         self_: BorrowedResourceGuard<Resource<Stream>>,
     ) -> HlResult<Result<u64, streams::StreamError<anyhow::Error>>> {
         let guard = self_.read().block_on();
-        Ok(guard
+        guard
             .check_write()
-            .map_err(|_| streams::StreamError::Closed))
+            .map_err(|_| streams::StreamError::Closed)
     }
     fn write(
         &mut self,
@@ -143,9 +141,9 @@ impl streams::OutputStream<anyhow::Error, Resource<Stream>, Resource<AnyPollable
         contents: Vec<u8>,
     ) -> HlResult<Result<(), streams::StreamError<anyhow::Error>>> {
         let mut guard = self_.write().block_on();
-        Ok(guard
+        guard
             .write(&contents)
-            .map_err(|_| streams::StreamError::Closed))
+            .map_err(|_| streams::StreamError::Closed)
     }
     fn blocking_write_and_flush(
         &mut self,
@@ -154,32 +152,32 @@ impl streams::OutputStream<anyhow::Error, Resource<Stream>, Resource<AnyPollable
     ) -> HlResult<Result<(), streams::StreamError<anyhow::Error>>> {
         let mut guard = self_.write_wait_until(Stream::writable).block_on();
         if guard.write(&contents).is_err() {
-            return Ok(Err(streams::StreamError::Closed));
+            return Err(streams::StreamError::Closed);
         }
         if guard.flush().is_err() {
-            return Ok(Err(streams::StreamError::Closed));
+            return Err(streams::StreamError::Closed);
         }
-        Ok(Ok(()))
+        Ok(())
     }
     fn flush(
         &mut self,
         self_: BorrowedResourceGuard<Resource<Stream>>,
     ) -> HlResult<Result<(), streams::StreamError<anyhow::Error>>> {
         let mut guard = self_.write().block_on();
-        Ok(guard.flush().map_err(|_| streams::StreamError::Closed))
+        guard.flush().map_err(|_| streams::StreamError::Closed)
     }
     fn blocking_flush(
         &mut self,
         self_: BorrowedResourceGuard<Resource<Stream>>,
     ) -> HlResult<Result<(), streams::StreamError<anyhow::Error>>> {
         let mut guard = self_.write().block_on();
-        Ok(guard.flush().map_err(|_| streams::StreamError::Closed))
+        guard.flush().map_err(|_| streams::StreamError::Closed)
     }
     fn subscribe(
         &mut self,
         self_: BorrowedResourceGuard<Resource<Stream>>,
     ) -> HlResult<Resource<AnyPollable>> {
-        Ok(self_.poll(|b| b.writable()))
+        self_.poll(|b| b.writable())
     }
     fn write_zeroes(
         &mut self,
@@ -188,9 +186,9 @@ impl streams::OutputStream<anyhow::Error, Resource<Stream>, Resource<AnyPollable
     ) -> HlResult<Result<(), streams::StreamError<anyhow::Error>>> {
         let capped = len.min(MAX_ALLOC_BYTES) as usize;
         let mut guard = self_.write().block_on();
-        Ok(guard
+        guard
             .write(vec![0; capped])
-            .map_err(|_| streams::StreamError::Closed))
+            .map_err(|_| streams::StreamError::Closed)
     }
     fn blocking_write_zeroes_and_flush(
         &mut self,
@@ -200,12 +198,12 @@ impl streams::OutputStream<anyhow::Error, Resource<Stream>, Resource<AnyPollable
         let capped = len.min(MAX_ALLOC_BYTES) as usize;
         let mut guard = self_.write().block_on();
         if guard.write(vec![0; capped]).is_err() {
-            return Ok(Err(streams::StreamError::Closed));
+            return Err(streams::StreamError::Closed);
         }
         if guard.flush().is_err() {
-            return Ok(Err(streams::StreamError::Closed));
+            return Err(streams::StreamError::Closed);
         }
-        Ok(Ok(()))
+        Ok(())
     }
     fn splice(
         &mut self,
@@ -215,10 +213,10 @@ impl streams::OutputStream<anyhow::Error, Resource<Stream>, Resource<AnyPollable
     ) -> HlResult<Result<u64, streams::StreamError<anyhow::Error>>> {
         let mut dst_guard = self_.write().block_on();
         let mut src_guard = src.write().block_on();
-        Ok(dst_guard
+        dst_guard
             .splice(&mut src_guard, len as usize)
             .map(|n| n as u64)
-            .map_err(|_| streams::StreamError::Closed))
+            .map_err(|_| streams::StreamError::Closed)
     }
     fn blocking_splice(
         &mut self,
@@ -228,10 +226,10 @@ impl streams::OutputStream<anyhow::Error, Resource<Stream>, Resource<AnyPollable
     ) -> HlResult<Result<u64, streams::StreamError<anyhow::Error>>> {
         let mut dst_guard = self_.write_wait_until(Stream::writable).block_on();
         let mut src_guard = src.write_wait_until(Stream::readable).block_on();
-        Ok(dst_guard
+        dst_guard
             .splice(&mut src_guard, len as usize)
             .map(|n| n as u64)
-            .map_err(|_| streams::StreamError::Closed))
+            .map_err(|_| streams::StreamError::Closed)
     }
 }
 

--- a/src/wasm_sandbox/src/wasi_impl/random.rs
+++ b/src/wasm_sandbox/src/wasi_impl/random.rs
@@ -8,15 +8,28 @@ type HlResult<T> = T;
 /// Maximum byte count for a single random-bytes allocation (16 MiB).
 const MAX_ALLOC_BYTES: u64 = 16 * 1024 * 1024;
 
+fn fill_random(buf: &mut [u8]) {
+    if let Err(err) = getrandom::fill(buf) {
+        log::error!("getrandom failed: {err}");
+    }
+}
+
+fn random_u64() -> u64 {
+    getrandom::u64().unwrap_or_else(|err| {
+        log::error!("getrandom failed: {err}");
+        0
+    })
+}
+
 impl wasi::random::Random for HostState {
     fn get_random_bytes(&mut self, len: u64) -> HlResult<Vec<u8>> {
         let capped = len.min(MAX_ALLOC_BYTES) as usize;
         let mut buf = vec![0u8; capped];
-        getrandom::fill(&mut buf).expect("getrandom failed");
+        fill_random(&mut buf);
         buf
     }
     fn get_random_u64(&mut self) -> HlResult<u64> {
-        getrandom::u64().expect("getrandom failed")
+        random_u64()
     }
 }
 
@@ -24,18 +37,16 @@ impl wasi::random::Insecure for HostState {
     fn get_insecure_random_bytes(&mut self, len: u64) -> HlResult<Vec<u8>> {
         let capped = len.min(MAX_ALLOC_BYTES) as usize;
         let mut buf = vec![0u8; capped];
-        getrandom::fill(&mut buf).expect("getrandom failed");
+        fill_random(&mut buf);
         buf
     }
     fn get_insecure_random_u64(&mut self) -> HlResult<u64> {
-        getrandom::u64().expect("getrandom failed")
+        random_u64()
     }
 }
 
 impl wasi::random::InsecureSeed for HostState {
     fn insecure_seed(&mut self) -> HlResult<(u64, u64)> {
-        let a = getrandom::u64().expect("getrandom failed");
-        let b = getrandom::u64().expect("getrandom failed");
-        (a, b)
+        (random_u64(), random_u64())
     }
 }

--- a/src/wasm_sandbox/src/wasi_impl/random.rs
+++ b/src/wasm_sandbox/src/wasi_impl/random.rs
@@ -1,11 +1,9 @@
 //! Random trait implementations.
 
-use hyperlight_host::HyperlightError;
-
 use crate::HostState;
 use crate::bindings::wasi;
 
-type HlResult<T> = Result<T, HyperlightError>;
+type HlResult<T> = T;
 
 /// Maximum byte count for a single random-bytes allocation (16 MiB).
 const MAX_ALLOC_BYTES: u64 = 16 * 1024 * 1024;
@@ -14,11 +12,11 @@ impl wasi::random::Random for HostState {
     fn get_random_bytes(&mut self, len: u64) -> HlResult<Vec<u8>> {
         let capped = len.min(MAX_ALLOC_BYTES) as usize;
         let mut buf = vec![0u8; capped];
-        getrandom::fill(&mut buf).map_err(|e| anyhow::anyhow!("getrandom failed: {e}"))?;
-        Ok(buf)
+        getrandom::fill(&mut buf).expect("getrandom failed");
+        buf
     }
     fn get_random_u64(&mut self) -> HlResult<u64> {
-        getrandom::u64().map_err(|e| anyhow::anyhow!("getrandom failed: {e}").into())
+        getrandom::u64().expect("getrandom failed")
     }
 }
 
@@ -26,18 +24,18 @@ impl wasi::random::Insecure for HostState {
     fn get_insecure_random_bytes(&mut self, len: u64) -> HlResult<Vec<u8>> {
         let capped = len.min(MAX_ALLOC_BYTES) as usize;
         let mut buf = vec![0u8; capped];
-        getrandom::fill(&mut buf).map_err(|e| anyhow::anyhow!("getrandom failed: {e}"))?;
-        Ok(buf)
+        getrandom::fill(&mut buf).expect("getrandom failed");
+        buf
     }
     fn get_insecure_random_u64(&mut self) -> HlResult<u64> {
-        getrandom::u64().map_err(|e| anyhow::anyhow!("getrandom failed: {e}").into())
+        getrandom::u64().expect("getrandom failed")
     }
 }
 
 impl wasi::random::InsecureSeed for HostState {
     fn insecure_seed(&mut self) -> HlResult<(u64, u64)> {
-        let a = getrandom::u64().map_err(|e| anyhow::anyhow!("getrandom failed: {e}"))?;
-        let b = getrandom::u64().map_err(|e| anyhow::anyhow!("getrandom failed: {e}"))?;
-        Ok((a, b))
+        let a = getrandom::u64().expect("getrandom failed");
+        let b = getrandom::u64().expect("getrandom failed");
+        (a, b)
     }
 }

--- a/src/wasm_sandbox/src/wasi_impl/sockets.rs
+++ b/src/wasm_sandbox/src/wasi_impl/sockets.rs
@@ -2,7 +2,6 @@
 #![allow(unused_variables)]
 
 use hyperlight_common::resource::BorrowedResourceGuard;
-use hyperlight_host::HyperlightError;
 use wasi::clocks::monotonic_clock;
 use wasi::sockets::{ip_name_lookup, network, tcp, udp};
 
@@ -12,7 +11,7 @@ use crate::wasi_impl::resource::Resource;
 use crate::wasi_impl::types::pollable::AnyPollable;
 use crate::wasi_impl::types::stream::Stream;
 
-type HlResult<T> = Result<T, HyperlightError>;
+type HlResult<T> = T;
 
 // ---------------------------------------------------------------------------
 // Sockets: Network
@@ -26,7 +25,7 @@ impl wasi::sockets::Network for HostState {}
 
 impl wasi::sockets::InstanceNetwork<u32> for HostState {
     fn instance_network(&mut self) -> HlResult<u32> {
-        Ok(0)
+        0
     }
 }
 
@@ -53,13 +52,13 @@ impl
         network: BorrowedResourceGuard<u32>,
         local_address: network::IpSocketAddress,
     ) -> HlResult<Result<(), network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn finish_bind(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<(), network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn start_connect(
         &mut self,
@@ -67,160 +66,160 @@ impl
         network: BorrowedResourceGuard<u32>,
         remote_address: network::IpSocketAddress,
     ) -> HlResult<Result<(), network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn finish_connect(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<(Resource<Stream>, Resource<Stream>), network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn start_listen(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<(), network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn finish_listen(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<(), network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn accept(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<(u32, Resource<Stream>, Resource<Stream>), network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn local_address(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<network::IpSocketAddress, network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn remote_address(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<network::IpSocketAddress, network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn is_listening(&mut self, self_: BorrowedResourceGuard<u32>) -> HlResult<bool> {
-        Ok(false)
+        false
     }
     fn address_family(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<network::IpAddressFamily> {
-        Ok(network::IpAddressFamily::Ipv4)
+        network::IpAddressFamily::Ipv4
     }
     fn set_listen_backlog_size(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
         value: u64,
     ) -> HlResult<Result<(), network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn keep_alive_enabled(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<bool, network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn set_keep_alive_enabled(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
         value: bool,
     ) -> HlResult<Result<(), network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn keep_alive_idle_time(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<monotonic_clock::Duration, network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn set_keep_alive_idle_time(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
         value: monotonic_clock::Duration,
     ) -> HlResult<Result<(), network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn keep_alive_interval(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<monotonic_clock::Duration, network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn set_keep_alive_interval(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
         value: monotonic_clock::Duration,
     ) -> HlResult<Result<(), network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn keep_alive_count(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<u32, network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn set_keep_alive_count(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
         value: u32,
     ) -> HlResult<Result<(), network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn hop_limit(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<u8, network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn set_hop_limit(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
         value: u8,
     ) -> HlResult<Result<(), network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn receive_buffer_size(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<u64, network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn set_receive_buffer_size(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
         value: u64,
     ) -> HlResult<Result<(), network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn send_buffer_size(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<u64, network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn set_send_buffer_size(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
         value: u64,
     ) -> HlResult<Result<(), network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn subscribe(&mut self, self_: BorrowedResourceGuard<u32>) -> HlResult<Resource<AnyPollable>> {
-        Ok(Resource::new(AnyPollable::future(std::future::ready(()))))
+        Resource::new(AnyPollable::future(std::future::ready(())))
     }
     fn shutdown(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
         shutdown_type: tcp::ShutdownType,
     ) -> HlResult<Result<(), network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
 }
 
@@ -245,7 +244,7 @@ impl wasi::sockets::TcpCreateSocket<network::ErrorCode, network::IpAddressFamily
         &mut self,
         address_family: network::IpAddressFamily,
     ) -> HlResult<Result<u32, network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
 }
 
@@ -264,10 +263,10 @@ impl
         max_results: u64,
     ) -> HlResult<Result<Vec<udp::IncomingDatagram<network::IpSocketAddress>>, network::ErrorCode>>
     {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn subscribe(&mut self, self_: BorrowedResourceGuard<u32>) -> HlResult<Resource<AnyPollable>> {
-        Ok(Resource::new(AnyPollable::future(std::future::ready(()))))
+        Resource::new(AnyPollable::future(std::future::ready(())))
     }
 }
 
@@ -280,17 +279,17 @@ impl
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<u64, network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn send(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
         datagrams: Vec<udp::OutgoingDatagram<network::IpSocketAddress>>,
     ) -> HlResult<Result<u64, network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn subscribe(&mut self, self_: BorrowedResourceGuard<u32>) -> HlResult<Resource<AnyPollable>> {
-        Ok(Resource::new(AnyPollable::future(std::future::ready(()))))
+        Resource::new(AnyPollable::future(std::future::ready(())))
     }
 }
 
@@ -312,80 +311,80 @@ impl
         network: BorrowedResourceGuard<u32>,
         local_address: network::IpSocketAddress,
     ) -> HlResult<Result<(), network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn finish_bind(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<(), network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn stream(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
         remote_address: Option<network::IpSocketAddress>,
     ) -> HlResult<Result<(u32, u32), network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn local_address(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<network::IpSocketAddress, network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn remote_address(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<network::IpSocketAddress, network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn address_family(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<network::IpAddressFamily> {
-        Ok(network::IpAddressFamily::Ipv4)
+        network::IpAddressFamily::Ipv4
     }
     fn unicast_hop_limit(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<u8, network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn set_unicast_hop_limit(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
         value: u8,
     ) -> HlResult<Result<(), network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn receive_buffer_size(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<u64, network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn set_receive_buffer_size(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
         value: u64,
     ) -> HlResult<Result<(), network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn send_buffer_size(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<u64, network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn set_send_buffer_size(
         &mut self,
         self_: BorrowedResourceGuard<u32>,
         value: u64,
     ) -> HlResult<Result<(), network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
     fn subscribe(&mut self, self_: BorrowedResourceGuard<u32>) -> HlResult<Resource<AnyPollable>> {
-        Ok(Resource::new(AnyPollable::future(std::future::ready(()))))
+        Resource::new(AnyPollable::future(std::future::ready(())))
     }
 }
 
@@ -407,7 +406,7 @@ impl wasi::sockets::UdpCreateSocket<network::ErrorCode, network::IpAddressFamily
         &mut self,
         address_family: network::IpAddressFamily,
     ) -> HlResult<Result<u32, network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::NotSupported))
+        Err(network::ErrorCode::NotSupported)
     }
 }
 
@@ -427,10 +426,10 @@ impl
         &mut self,
         self_: BorrowedResourceGuard<u32>,
     ) -> HlResult<Result<Option<network::IpAddress>, network::ErrorCode>> {
-        Ok(Ok(None))
+        Ok(None)
     }
     fn subscribe(&mut self, self_: BorrowedResourceGuard<u32>) -> HlResult<Resource<AnyPollable>> {
-        Ok(Resource::new(AnyPollable::future(std::future::ready(()))))
+        Resource::new(AnyPollable::future(std::future::ready(())))
     }
 }
 
@@ -442,6 +441,6 @@ impl wasi::sockets::IpNameLookup<network::ErrorCode, network::IpAddress, u32, Re
         network: BorrowedResourceGuard<u32>,
         name: String,
     ) -> HlResult<Result<u32, network::ErrorCode>> {
-        Ok(Err(network::ErrorCode::PermanentResolverFailure))
+        Err(network::ErrorCode::PermanentResolverFailure)
     }
 }


### PR DESCRIPTION
Updates the sandbox to exercise the current Hyperlight component bindgen fix stack.

Pins the Hyperlight and hyperlight-wasm fork branches, updates compatible component dependencies, and adjusts the WASI host implementations for the new host-bindgen Result shape.