### PR TITLE
Bump hyperlight sandbox to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-javascript-sandbox"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "hyperlight-js",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-sandbox"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-sandbox-backend-hyperlight-js"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "hyperlight-javascript-sandbox",
  "hyperlight-sandbox",
@@ -1947,7 +1947,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-sandbox-backend-wasm"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "hyperlight-sandbox",
  "hyperlight-sandbox-pyo3-common",
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-sandbox-dotnet-ffi"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "hyperlight-javascript-sandbox",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-sandbox-pyo3-common"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "hyperlight-sandbox",
@@ -2043,7 +2043,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-wasm-sandbox"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hyperlight-sandbox-dev"
-version = "0.4.0"
+version = "0.5.0"
 requires-python = ">=3.10"
 
 [tool.uv]

--- a/src/sdk/dotnet/Directory.Build.props
+++ b/src/sdk/dotnet/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <Authors>Hyperlight developers</Authors>
     <Company>hyperlight-dev</Company>
     <Copyright>Copyright © Microsoft 2026</Copyright>

--- a/src/sdk/python/core/pyproject.toml
+++ b/src/sdk/python/core/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hyperlight-sandbox"
-version = "0.4.0"
+version = "0.5.0"
 description = "Python API for running code in isolated Hyperlight sandboxes with swappable backends"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = []
-optional-dependencies = { wasm = ["hyperlight-sandbox-backend-wasm>=0.4.0"], hyperlight_js = ["hyperlight-sandbox-backend-hyperlight-js>=0.4.0"], python_guest = ["hyperlight-sandbox-python-guest>=0.4.0"], javascript_guest = ["hyperlight-sandbox-javascript-guest>=0.4.0"], dev = ["atheris>=2.3.0; python_version < '3.13'"] }
+optional-dependencies = { wasm = ["hyperlight-sandbox-backend-wasm>=0.5.0"], hyperlight_js = ["hyperlight-sandbox-backend-hyperlight-js>=0.5.0"], python_guest = ["hyperlight-sandbox-python-guest>=0.5.0"], javascript_guest = ["hyperlight-sandbox-javascript-guest>=0.5.0"], dev = ["atheris>=2.3.0; python_version < '3.13'"] }
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",

--- a/src/sdk/python/hyperlight_js_backend/pyproject.toml
+++ b/src/sdk/python/hyperlight_js_backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "hyperlight-sandbox-backend-hyperlight-js"
-version = "0.4.0"
+version = "0.5.0"
 description = "HyperlightJS backend implementation for hyperlight-sandbox"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sdk/python/wasm_backend/pyproject.toml
+++ b/src/sdk/python/wasm_backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "hyperlight-sandbox-backend-wasm"
-version = "0.4.0"
+version = "0.5.0"
 description = "Wasm backend implementation for hyperlight-sandbox"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sdk/python/wasm_guests/javascript_guest/pyproject.toml
+++ b/src/sdk/python/wasm_guests/javascript_guest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hyperlight-sandbox-javascript-guest"
-version = "0.4.0"
+version = "0.5.0"
 description = "Packaged Hyperlight Wasm JavaScript guest exposed as javascript_guest.path"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sdk/python/wasm_guests/python_guest/pyproject.toml
+++ b/src/sdk/python/wasm_guests/python_guest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hyperlight-sandbox-python-guest"
-version = "0.4.0"
+version = "0.5.0"
 description = "Packaged Hyperlight Wasm Python guest exposed as python_guest.path"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/wasm_sandbox/guests/javascript/package-lock.json
+++ b/src/wasm_sandbox/guests/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hyperlight-sandbox-js-guest",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hyperlight-sandbox-js-guest",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "devDependencies": {
         "@bytecodealliance/componentize-js": "^0.21.0",
         "@bytecodealliance/jco": "^1.24.3"

--- a/src/wasm_sandbox/guests/javascript/package.json
+++ b/src/wasm_sandbox/guests/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperlight-sandbox-js-guest",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/uv.lock
+++ b/uv.lock
@@ -532,7 +532,7 @@ wheels = [
 
 [[package]]
 name = "hyperlight-sandbox"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "src/sdk/python/core" }
 
 [package.optional-dependencies]
@@ -564,17 +564,17 @@ provides-extras = ["wasm", "hyperlight-js", "python-guest", "javascript-guest", 
 
 [[package]]
 name = "hyperlight-sandbox-backend-hyperlight-js"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "src/sdk/python/hyperlight_js_backend" }
 
 [[package]]
 name = "hyperlight-sandbox-backend-wasm"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "src/sdk/python/wasm_backend" }
 
 [[package]]
 name = "hyperlight-sandbox-dev"
-version = "0.4.0"
+version = "0.5.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]
@@ -638,12 +638,12 @@ dev = [
 
 [[package]]
 name = "hyperlight-sandbox-javascript-guest"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "src/sdk/python/wasm_guests/javascript_guest" }
 
 [[package]]
 name = "hyperlight-sandbox-python-guest"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "src/sdk/python/wasm_guests/python_guest" }
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump Hyperlight Sandbox package versions from 0.4.0 to 0.5.0 across Rust, Python, JavaScript, and .NET manifests.
- Update internal package version metadata in Cargo, uv, and npm lockfiles.