### PR TITLE
Build Python wheels for manylinux 2.28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,10 +255,14 @@ jobs:
       - name: Benchmark
         run: just benchmark
 
-  # Build all Python packages on Linux (pure + backend wheels).
+  # Build all Python packages on Linux for glibc 2.28 and newer.
   python-wheelhouse-build-linux:
-    name: Python wheelhouse build (Linux)
+    name: Python wheelhouse build (manylinux_2_28)
     runs-on: ubuntu-latest
+    container:
+      image: quay.io/pypa/manylinux_2_28_x86_64@sha256:f854c50adf7b7a325bc4794316f3758d387a41d61f9e2ebca0f26c7dc8f761d4
+    env:
+      MANYLINUX: "2_28"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
@@ -282,12 +286,24 @@ jobs:
         run: cargo install --locked just
 
       - name: Install clang
-        run: sudo apt-get update && sudo apt-get install -y clang
+        run: dnf install -y clang
 
       - name: Build all Python packages
         run: |
           export INTERPRETERS="--interpreter $(uv python find 3.10) $(uv python find 3.11) $(uv python find 3.12) $(uv python find 3.13) $(uv python find 3.14)"
           just python-dist
+
+      - name: Verify manylinux compatibility
+        run: |
+          for wheel in dist/pythonsdk/{wasm_backend,hyperlight_js_backend}/*.whl; do
+            case "$wheel" in
+              *-manylinux_2_28_x86_64.whl) ;;
+              *)
+                echo "::error::Unexpected Linux wheel tag: $wheel"
+                exit 1
+                ;;
+            esac
+          done
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,11 +20,15 @@ permissions:
   contents: read
 
 jobs:
-  # Build all Python packages on Linux (pure + backend wheels).
+  # Build all Python packages on Linux for glibc 2.28 and newer.
   build-linux:
     if: ${{ !github.event.act && (github.event_name != 'workflow_dispatch' || inputs.publish_target == 'all' || inputs.publish_target == 'python') }}
-    name: Build Linux packages
+    name: Build Linux packages (manylinux_2_28)
     runs-on: ubuntu-latest
+    container:
+      image: quay.io/pypa/manylinux_2_28_x86_64@sha256:f854c50adf7b7a325bc4794316f3758d387a41d61f9e2ebca0f26c7dc8f761d4
+    env:
+      MANYLINUX: "2_28"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
@@ -48,12 +52,24 @@ jobs:
         run: cargo install --locked just
 
       - name: Install clang
-        run: sudo apt-get update && sudo apt-get install -y clang
+        run: dnf install -y clang
 
       - name: Build all Python packages
         run: |
           export INTERPRETERS="--interpreter $(uv python find 3.10) $(uv python find 3.11) $(uv python find 3.12) $(uv python find 3.13) $(uv python find 3.14)"
           just python-dist
+
+      - name: Verify manylinux compatibility
+        run: |
+          for wheel in dist/pythonsdk/{wasm_backend,hyperlight_js_backend}/*.whl; do
+            case "$wheel" in
+              *-manylinux_2_28_x86_64.whl) ;;
+              *)
+                echo "::error::Unexpected Linux wheel tag: $wheel"
+                exit 1
+                ;;
+            esac
+          done
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:

--- a/src/sdk/python/Justfile
+++ b/src/sdk/python/Justfile
@@ -11,6 +11,9 @@ python-version-flag := "--python"
 # Set via env or CLI (e.g. `just interpreters="--interpreter python3.10 python3.14" python-dist`)
 # to build wheels for multiple Python versions. Defaults to empty (maturin uses active Python).
 interpreters := env("INTERPRETERS", "")
+# Set in Linux wheel builds to enforce and audit a specific manylinux policy.
+manylinux := env("MANYLINUX", "")
+manylinux-arg := if manylinux != "" { "--manylinux " + manylinux } else { "" }
 # Atheris currently supports fuzzing on Python <= 3.12. Keep the rest of the
 # SDK test/build surface on the active Python while running fuzz on 3.12.
 default-fuzz-python := "3.12"
@@ -69,8 +72,8 @@ build: python-build
 python-dist: python-sync-guest-resources
     -{{rmrf}} {{dist-root}}
     cd {{repo-root}}/src/sdk/python/core && uv run python -m build --outdir {{core-dist}}
-    cd {{repo-root}}/src/sdk/python/wasm_backend && uv run maturin build --release --out {{wasm-wheels}} {{interpreters}}
-    cd {{repo-root}}/src/sdk/python/hyperlight_js_backend && uv run maturin build --release --out {{hyperlight-js-wheels}} {{interpreters}}
+    cd {{repo-root}}/src/sdk/python/wasm_backend && uv run maturin build --release --out {{wasm-wheels}} {{manylinux-arg}} {{interpreters}}
+    cd {{repo-root}}/src/sdk/python/hyperlight_js_backend && uv run maturin build --release --out {{hyperlight-js-wheels}} {{manylinux-arg}} {{interpreters}}
     cd {{repo-root}}/src/sdk/python/wasm_guests/python_guest && uv run python -m build --outdir {{python-guest-dist}}
     cd {{repo-root}}/src/sdk/python/wasm_guests/javascript_guest && uv run python -m build --outdir {{javascript-guest-dist}}
 
@@ -80,8 +83,8 @@ python-dist: python-sync-guest-resources
 python-dist-backends: python-sync-env
     -{{rmrf}} {{wasm-wheels}}
     -{{rmrf}} {{hyperlight-js-wheels}}
-    cd {{repo-root}}/src/sdk/python/wasm_backend && uv run maturin build --release --out {{wasm-wheels}} {{interpreters}}
-    cd {{repo-root}}/src/sdk/python/hyperlight_js_backend && uv run maturin build --release --out {{hyperlight-js-wheels}} {{interpreters}}
+    cd {{repo-root}}/src/sdk/python/wasm_backend && uv run maturin build --release --out {{wasm-wheels}} {{manylinux-arg}} {{interpreters}}
+    cd {{repo-root}}/src/sdk/python/hyperlight_js_backend && uv run maturin build --release --out {{hyperlight-js-wheels}} {{manylinux-arg}} {{interpreters}}
 
 python-publish repository="pypi":
     uv publish {{ if repository != "pypi" { "--publish-url https://test.pypi.org/legacy/" } else { "" } }} {{wasm-wheels}}/*


### PR DESCRIPTION
Issue #141 requests Python backend wheels that install on HPC systems using glibc 2.28. The current Ubuntu-hosted builds produce `manylinux_2_34` wheels, excluding those systems.

This updates CI and publishing to run the existing `just python-dist` flow inside a digest-pinned official PyPA `manylinux_2_28` environment. The Justfile passes the requested manylinux policy to maturin, and both workflows reject native wheels without the expected `manylinux_2_28_x86_64` tag. A single 2.28 wheel set remains compatible with glibc 2.34 and newer.

Closes #141