### PR TITLE
Update cap-std to 4.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+checksum = "8b5f74729fd2f44701d1a8eb47e906cdb3ccd9ec0f02baad85a744b791940b18"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
@@ -382,11 +382,11 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+checksum = "c1ec78e242cfa2cfe276807ac2ecc00315a6c97786977414bcd1c3963b6c91b8"
 dependencies = [
- "cap-primitives 4.0.2",
+ "cap-primitives 4.0.3",
  "io-extras 0.19.0",
  "io-lifetimes 3.0.1",
  "rustix 1.1.4",
@@ -1918,7 +1918,7 @@ dependencies = [
  "anyhow",
  "bitflags 2.13.0",
  "bytes",
- "cap-std 4.0.2",
+ "cap-std 4.0.3",
  "futures-util",
  "http",
  "http-body",

--- a/src/hyperlight_sandbox/Cargo.toml
+++ b/src/hyperlight_sandbox/Cargo.toml
@@ -10,7 +10,7 @@ description = "High-level Rust host library for running sandbox guests across mu
 anyhow = "1"
 bitflags = "2"
 bytes = "1"
-cap-std = "4.0.2"
+cap-std = "4.0.3"
 http = "1"
 http-body-util = "0.1"
 hyper = { version = "1", features = ["server", "http1"] }


### PR DESCRIPTION
Updates `cap-std` from 4.0.2 to 4.0.3 to pick up the latest compatible patch release. The lockfile also updates the matching `cap-primitives` package to 4.0.3.