### PR TITLE
Use upstream Hyperlight dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,7 +1147,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1230,7 +1230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2043,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-wasm"
 version = "0.14.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight-wasm?rev=9292704a41316899d9d9c58e080a60ad331ab28d#9292704a41316899d9d9c58e080a60ad331ab28d"
+source = "git+https://github.com/hyperlight-dev/hyperlight-wasm?rev=f2ee1fe662adbba313cf3155b460d8fdb36b0793#f2ee1fe662adbba313cf3155b460d8fdb36b0793"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2073,7 +2073,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-wasm-macro"
 version = "0.14.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight-wasm?rev=9292704a41316899d9d9c58e080a60ad331ab28d#9292704a41316899d9d9c58e080a60ad331ab28d"
+source = "git+https://github.com/hyperlight-dev/hyperlight-wasm?rev=f2ee1fe662adbba313cf3155b460d8fdb36b0793#f2ee1fe662adbba313cf3155b460d8fdb36b0793"
 dependencies = [
  "hyperlight-component-util",
  "itertools 0.15.0",
@@ -2085,7 +2085,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-wasm-runtime"
 version = "0.14.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight-wasm?rev=9292704a41316899d9d9c58e080a60ad331ab28d#9292704a41316899d9d9c58e080a60ad331ab28d"
+source = "git+https://github.com/hyperlight-dev/hyperlight-wasm?rev=f2ee1fe662adbba313cf3155b460d8fdb36b0793#f2ee1fe662adbba313cf3155b460d8fdb36b0793"
 dependencies = [
  "cargo_metadata",
  "cc",
@@ -2292,7 +2292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2414,7 +2414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
 dependencies = [
  "scopeguard",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3502,7 +3502,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3898,7 +3898,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4939,7 +4939,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,7 +1147,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1230,7 +1230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2043,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-wasm"
 version = "0.14.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight-wasm?rev=f2ee1fe662adbba313cf3155b460d8fdb36b0793#f2ee1fe662adbba313cf3155b460d8fdb36b0793"
+source = "git+https://github.com/hyperlight-dev/hyperlight-wasm?rev=2757fb9ff3e117c1513c325b3b32d3abd9918e9d#2757fb9ff3e117c1513c325b3b32d3abd9918e9d"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2073,7 +2073,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-wasm-macro"
 version = "0.14.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight-wasm?rev=f2ee1fe662adbba313cf3155b460d8fdb36b0793#f2ee1fe662adbba313cf3155b460d8fdb36b0793"
+source = "git+https://github.com/hyperlight-dev/hyperlight-wasm?rev=2757fb9ff3e117c1513c325b3b32d3abd9918e9d#2757fb9ff3e117c1513c325b3b32d3abd9918e9d"
 dependencies = [
  "hyperlight-component-util",
  "itertools 0.15.0",
@@ -2085,7 +2085,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-wasm-runtime"
 version = "0.14.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight-wasm?rev=f2ee1fe662adbba313cf3155b460d8fdb36b0793#f2ee1fe662adbba313cf3155b460d8fdb36b0793"
+source = "git+https://github.com/hyperlight-dev/hyperlight-wasm?rev=2757fb9ff3e117c1513c325b3b32d3abd9918e9d#2757fb9ff3e117c1513c325b3b32d3abd9918e9d"
 dependencies = [
  "cargo_metadata",
  "cc",
@@ -2292,7 +2292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2414,7 +2414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
 dependencies = [
  "scopeguard",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3502,7 +3502,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3898,7 +3898,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4939,7 +4939,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -166,13 +166,13 @@ dependencies = [
  "clang-sys",
  "itertools 0.13.0",
  "log",
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -223,6 +223,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -280,7 +289,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -561,7 +570,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -619,6 +628,12 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const_format"
@@ -1004,6 +1019,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,7 +1048,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1035,7 +1059,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1070,7 +1094,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1080,7 +1104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1089,9 +1113,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1123,7 +1158,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1380,7 +1415,7 @@ checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1462,7 +1497,7 @@ checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1619,7 +1654,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1668,6 +1703,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1705,8 +1749,8 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-common"
-version = "0.15.0"
-source = "git+https://github.com/jsturtevant/hyperlight-1?rev=2640a824b59d18e633e706e5639c7da30e7ad5fc#2640a824b59d18e633e706e5639c7da30e7ad5fc"
+version = "0.16.0"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=cfa020441d880d599cc516a050e6cf10236ca5c4#cfa020441d880d599cc516a050e6cf10236ca5c4"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -1724,36 +1768,39 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-component-macro"
-version = "0.15.0"
-source = "git+https://github.com/jsturtevant/hyperlight-1?rev=2640a824b59d18e633e706e5639c7da30e7ad5fc#2640a824b59d18e633e706e5639c7da30e7ad5fc"
+version = "0.16.0"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=cfa020441d880d599cc516a050e6cf10236ca5c4#cfa020441d880d599cc516a050e6cf10236ca5c4"
 dependencies = [
  "env_logger",
  "hyperlight-component-util",
  "itertools 0.15.0",
- "prettyplease",
+ "prettyplease 0.3.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "hyperlight-component-util"
-version = "0.15.0"
-source = "git+https://github.com/jsturtevant/hyperlight-1?rev=2640a824b59d18e633e706e5639c7da30e7ad5fc#2640a824b59d18e633e706e5639c7da30e7ad5fc"
+version = "0.16.0"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=cfa020441d880d599cc516a050e6cf10236ca5c4#cfa020441d880d599cc516a050e6cf10236ca5c4"
 dependencies = [
  "itertools 0.15.0",
- "prettyplease",
+ "prettyplease 0.3.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
  "tracing",
- "wasmparser 0.252.0",
+ "wasmparser 0.256.0",
+ "wat",
+ "wit-component",
+ "wit-parser 0.256.0",
 ]
 
 [[package]]
 name = "hyperlight-guest"
-version = "0.15.0"
-source = "git+https://github.com/jsturtevant/hyperlight-1?rev=2640a824b59d18e633e706e5639c7da30e7ad5fc#2640a824b59d18e633e706e5639c7da30e7ad5fc"
+version = "0.16.0"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=cfa020441d880d599cc516a050e6cf10236ca5c4#cfa020441d880d599cc516a050e6cf10236ca5c4"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -1764,8 +1811,8 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest-bin"
-version = "0.15.0"
-source = "git+https://github.com/jsturtevant/hyperlight-1?rev=2640a824b59d18e633e706e5639c7da30e7ad5fc#2640a824b59d18e633e706e5639c7da30e7ad5fc"
+version = "0.16.0"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=cfa020441d880d599cc516a050e6cf10236ca5c4#cfa020441d880d599cc516a050e6cf10236ca5c4"
 dependencies = [
  "buddy_system_allocator",
  "flatbuffers",
@@ -1782,19 +1829,19 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest-macro"
-version = "0.15.0"
-source = "git+https://github.com/jsturtevant/hyperlight-1?rev=2640a824b59d18e633e706e5639c7da30e7ad5fc#2640a824b59d18e633e706e5639c7da30e7ad5fc"
+version = "0.16.0"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=cfa020441d880d599cc516a050e6cf10236ca5c4#cfa020441d880d599cc516a050e6cf10236ca5c4"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "hyperlight-guest-tracing"
-version = "0.15.0"
-source = "git+https://github.com/jsturtevant/hyperlight-1?rev=2640a824b59d18e633e706e5639c7da30e7ad5fc#2640a824b59d18e633e706e5639c7da30e7ad5fc"
+version = "0.16.0"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=cfa020441d880d599cc516a050e6cf10236ca5c4#cfa020441d880d599cc516a050e6cf10236ca5c4"
 dependencies = [
  "hyperlight-common",
  "spin 0.12.0",
@@ -1804,13 +1851,15 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-host"
-version = "0.15.0"
-source = "git+https://github.com/jsturtevant/hyperlight-1?rev=2640a824b59d18e633e706e5639c7da30e7ad5fc#2640a824b59d18e633e706e5639c7da30e7ad5fc"
+version = "0.16.0"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=cfa020441d880d599cc516a050e6cf10236ca5c4#cfa020441d880d599cc516a050e6cf10236ca5c4"
 dependencies = [
  "anyhow",
+ "bindgen",
  "bitflags 2.13.0",
  "blake3",
  "bytemuck",
+ "cc",
  "cfg-if",
  "cfg_aliases",
  "crossbeam-channel",
@@ -1828,11 +1877,12 @@ dependencies = [
  "mshv-ioctls",
  "oci-spec",
  "page_size",
+ "parking_lot",
  "rand 0.10.1",
  "rust-embed",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
  "termcolor",
  "thiserror",
@@ -1861,13 +1911,14 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-js"
-version = "0.2.5"
-source = "git+https://github.com/hyperlight-dev/hyperlight-js.git?rev=915608fbc30e922c7ed03aa08b05c3a3a5614f39#915608fbc30e922c7ed03aa08b05c3a3a5614f39"
+version = "0.3.3"
+source = "git+https://github.com/hyperlight-dev/hyperlight-js.git?rev=b96774e7e19ce1945775498cd83d305a915e28df#b96774e7e19ce1945775498cd83d305a915e28df"
 dependencies = [
  "anyhow",
  "cargo-hyperlight",
  "fn-traits",
  "hyperlight-host",
+ "hyperlight-js-common",
  "hyperlight-js-runtime",
  "metrics",
  "oxc_resolver",
@@ -1879,9 +1930,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyperlight-js-common"
+version = "0.3.3"
+source = "git+https://github.com/hyperlight-dev/hyperlight-js.git?rev=b96774e7e19ce1945775498cd83d305a915e28df#b96774e7e19ce1945775498cd83d305a915e28df"
+
+[[package]]
 name = "hyperlight-js-runtime"
-version = "0.2.5"
-source = "git+https://github.com/hyperlight-dev/hyperlight-js.git?rev=915608fbc30e922c7ed03aa08b05c3a3a5614f39#915608fbc30e922c7ed03aa08b05c3a3a5614f39"
+version = "0.3.3"
+source = "git+https://github.com/hyperlight-dev/hyperlight-js.git?rev=b96774e7e19ce1945775498cd83d305a915e28df#b96774e7e19ce1945775498cd83d305a915e28df"
 dependencies = [
  "anyhow",
  "base64",
@@ -1891,19 +1947,22 @@ dependencies = [
  "hashbrown 0.17.0",
  "hex",
  "hmac",
+ "hyperlight-common",
+ "hyperlight-guest",
  "hyperlight-guest-bin",
+ "hyperlight-js-common",
  "rquickjs",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "spin 0.12.0",
  "tracing",
 ]
 
 [[package]]
 name = "hyperlight-libc"
-version = "0.15.0"
-source = "git+https://github.com/jsturtevant/hyperlight-1?rev=2640a824b59d18e633e706e5639c7da30e7ad5fc#2640a824b59d18e633e706e5639c7da30e7ad5fc"
+version = "0.16.0"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=cfa020441d880d599cc516a050e6cf10236ca5c4#cfa020441d880d599cc516a050e6cf10236ca5c4"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -1984,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-wasm"
 version = "0.14.0"
-source = "git+https://github.com/jsturtevant/hyperlight-wasm?rev=447c5893fc916f1e9faf9aaac59afc45e6591d1f#447c5893fc916f1e9faf9aaac59afc45e6591d1f"
+source = "git+https://github.com/hyperlight-dev/hyperlight-wasm?rev=9292704a41316899d9d9c58e080a60ad331ab28d#9292704a41316899d9d9c58e080a60ad331ab28d"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2014,11 +2073,11 @@ dependencies = [
 [[package]]
 name = "hyperlight-wasm-macro"
 version = "0.14.0"
-source = "git+https://github.com/jsturtevant/hyperlight-wasm?rev=447c5893fc916f1e9faf9aaac59afc45e6591d1f#447c5893fc916f1e9faf9aaac59afc45e6591d1f"
+source = "git+https://github.com/hyperlight-dev/hyperlight-wasm?rev=9292704a41316899d9d9c58e080a60ad331ab28d#9292704a41316899d9d9c58e080a60ad331ab28d"
 dependencies = [
  "hyperlight-component-util",
  "itertools 0.15.0",
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
 ]
@@ -2026,7 +2085,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-wasm-runtime"
 version = "0.14.0"
-source = "git+https://github.com/jsturtevant/hyperlight-wasm?rev=447c5893fc916f1e9faf9aaac59afc45e6591d1f#447c5893fc916f1e9faf9aaac59afc45e6591d1f"
+source = "git+https://github.com/hyperlight-dev/hyperlight-wasm?rev=9292704a41316899d9d9c58e080a60ad331ab28d#9292704a41316899d9d9c58e080a60ad331ab28d"
 dependencies = [
  "cargo_metadata",
  "cc",
@@ -2314,7 +2373,7 @@ checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2481,7 +2540,7 @@ checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2641,7 +2700,7 @@ checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2670,9 +2729,9 @@ dependencies = [
 
 [[package]]
 name = "oci-spec"
-version = "0.8.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3da52b83ce3258fbf29f66ac784b279453c2ac3c22c5805371b921ede0d308"
+checksum = "3df6f876ad774d6a676f7e968f5c3edacc32f90e65fe680a8b686235396556fb"
 dependencies = [
  "const_format",
  "derive_builder",
@@ -2809,7 +2868,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2838,7 +2897,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2911,7 +2970,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
+dependencies = [
+ "proc-macro2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2983,7 +3052,7 @@ checksum = "055100cf63f790c7bd02e606339916e1a403485358d4ae890ce912c102a9e80d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2994,7 +3063,7 @@ checksum = "f4389e5820b1b39810ac12a27aa665320cab3caa51913a79637c06f284cfe223"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3039,7 +3108,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3051,7 +3120,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3221,7 +3290,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3340,7 +3409,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rquickjs-core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3374,7 +3443,7 @@ dependencies = [
  "quote",
  "rust-embed-utils",
  "shellexpand",
- "syn",
+ "syn 2.0.117",
  "walkdir",
 ]
 
@@ -3385,7 +3454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
  "globset",
- "sha2",
+ "sha2 0.10.9",
  "walkdir",
 ]
 
@@ -3537,7 +3606,7 @@ checksum = "ed76efe62313ab6610570951494bdaa81568026e0318eaa55f167de70eeea67d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3583,7 +3652,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3608,7 +3677,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3733,7 +3813,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3754,6 +3834,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3761,7 +3852,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3836,7 +3927,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3874,7 +3965,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3950,7 +4041,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4161,7 +4252,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -4195,6 +4286,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.256.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1492381bfd5ea51c2a99a919b676662559925cb8d7490547ec2e14c1ad3eb1"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.256.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.257.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8ad9f0a39050867bda22e6486c316e2e52d20a42154d5bc433934bf738d085"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.257.1",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.256.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6187f9fce741db43bea48f1ec42174897d763b8cdea7df726f2dd05561848d7"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder 0.256.0",
+ "wasmparser 0.256.0",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4222,15 +4345,26 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.252.0"
+version = "0.256.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
+checksum = "60bd825ffedc6cba8a642924ba7ae424afbc47811cffbcb7b92031ec24e59b4c"
 dependencies = [
  "bitflags 2.13.0",
  "hashbrown 0.17.0",
  "indexmap",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.257.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92fc335fb6d48f46bda1d8b26b69e28320c15ac3272208333833d6e217e2b4a"
+dependencies = [
+ "bitflags 2.13.0",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -4383,7 +4517,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_derive",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
  "wasm-encoder 0.246.2",
@@ -4411,7 +4545,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasmtime-internal-component-util 36.0.11",
  "wasmtime-internal-wit-bindgen 36.0.11",
  "wit-parser 0.236.1",
@@ -4426,7 +4560,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasmtime-internal-component-util 44.0.2",
  "wasmtime-internal-wit-bindgen 44.0.2",
  "wit-parser 0.246.2",
@@ -4594,7 +4728,7 @@ checksum = "e69f8a29ae6fdf7218ae37f38b1cc9fe539344a17b7fffba203de3ee2194d605"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4605,7 +4739,7 @@ checksum = "7a12754f1ffc4a3300d56d324c418b8b32cf029606618da22c7d076213882a3f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4731,6 +4865,28 @@ dependencies = [
  "futures",
  "tracing",
  "wasmtime 44.0.2",
+]
+
+[[package]]
+name = "wast"
+version = "257.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c416ee8044cf88c5280e3d87c322b009525eb25142cf7428f0a90ea88febc3b"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder 0.257.1",
+]
+
+[[package]]
+name = "wat"
+version = "1.257.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "672e5495f00c5fc6c6b502205bae4708aa4dd13d969754438743afe0a8af0f1d"
+dependencies = [
+ "wast",
 ]
 
 [[package]]
@@ -4884,7 +5040,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4895,7 +5051,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5141,6 +5297,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "wit-component"
+version = "0.256.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d537ec182eed18f560184b870287cf443c4eccc315af178db3eae8811c3b6c"
+dependencies = [
+ "anyhow",
+ "bitflags 2.13.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.256.0",
+ "wasm-metadata",
+ "wasmparser 0.256.0",
+ "wit-parser 0.256.0",
+]
+
+[[package]]
 name = "wit-parser"
 version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5178,6 +5353,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-parser"
+version = "0.256.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa073dadefba859cb03f689a0c2e3efc51f883bf86b907eaa9709bfd9e3a00a9"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.0",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-ident",
+ "wasmparser 0.256.0",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5212,7 +5406,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5233,7 +5427,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5253,7 +5447,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5293,7 +5487,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ hyperlight-common = { git = "https://github.com/hyperlight-dev/hyperlight", rev 
 hyperlight-component-macro = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "cfa020441d880d599cc516a050e6cf10236ca5c4" }
 hyperlight-host = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "cfa020441d880d599cc516a050e6cf10236ca5c4", default-features = false, features = ["executable_heap"] }
 # https://github.com/hyperlight-dev/hyperlight-wasm/pull/520
-hyperlight-wasm = { git = "https://github.com/hyperlight-dev/hyperlight-wasm", rev = "f2ee1fe662adbba313cf3155b460d8fdb36b0793" }
+hyperlight-wasm = { git = "https://github.com/hyperlight-dev/hyperlight-wasm", rev = "2757fb9ff3e117c1513c325b3b32d3abd9918e9d" }
 pyo3 = { version = "0.29", features = ["extension-module"] }
 
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ hyperlight-common = { git = "https://github.com/hyperlight-dev/hyperlight", rev 
 hyperlight-component-macro = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "cfa020441d880d599cc516a050e6cf10236ca5c4" }
 hyperlight-host = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "cfa020441d880d599cc516a050e6cf10236ca5c4", default-features = false, features = ["executable_heap"] }
 # https://github.com/hyperlight-dev/hyperlight-wasm/pull/520
-hyperlight-wasm = { git = "https://github.com/hyperlight-dev/hyperlight-wasm", rev = "9292704a41316899d9d9c58e080a60ad331ab28d" }
+hyperlight-wasm = { git = "https://github.com/hyperlight-dev/hyperlight-wasm", rev = "f2ee1fe662adbba313cf3155b460d8fdb36b0793" }
 pyo3 = { version = "0.29", features = ["extension-module"] }
 
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 [workspace.package]
 version = "0.5.0"
 edition = "2024"
-rust-version = "1.89"
+rust-version = "1.94"
 license = "Apache-2.0"
 
 [workspace.dependencies]
@@ -21,18 +21,17 @@ hyperlight-sandbox = { path = "src/hyperlight_sandbox" }
 hyperlight-javascript-sandbox = { path = "src/javascript_sandbox" }
 hyperlight-wasm-sandbox = { path = "src/wasm_sandbox" }
 hyperlight-sandbox-pyo3-common = { path = "src/sdk/python/pyo3_common" }
-hyperlight-common = { version = "0.15.0", default-features = false }
-hyperlight-component-macro = { version = "0.15.0" }
-hyperlight-host = { version = "0.15.0", default-features = false, features = ["executable_heap"] }
-# https://github.com/jsturtevant/hyperlight-wasm/tree/sandbox-component-bindgen-prs
-hyperlight-wasm = { git = "https://github.com/jsturtevant/hyperlight-wasm", rev = "447c5893fc916f1e9faf9aaac59afc45e6591d1f" }
+hyperlight-common = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "cfa020441d880d599cc516a050e6cf10236ca5c4", default-features = false }
+hyperlight-component-macro = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "cfa020441d880d599cc516a050e6cf10236ca5c4" }
+hyperlight-host = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "cfa020441d880d599cc516a050e6cf10236ca5c4", default-features = false, features = ["executable_heap"] }
+# https://github.com/hyperlight-dev/hyperlight-wasm/pull/520
+hyperlight-wasm = { git = "https://github.com/hyperlight-dev/hyperlight-wasm", rev = "9292704a41316899d9d9c58e080a60ad331ab28d" }
 pyo3 = { version = "0.29", features = ["extension-module"] }
 
 [patch.crates-io]
-# https://github.com/jsturtevant/hyperlight-1/tree/sandbox-component-bindgen-prs
-hyperlight-common = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "2640a824b59d18e633e706e5639c7da30e7ad5fc", package = "hyperlight-common" }
-hyperlight-component-macro = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "2640a824b59d18e633e706e5639c7da30e7ad5fc", package = "hyperlight-component-macro" }
-hyperlight-component-util = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "2640a824b59d18e633e706e5639c7da30e7ad5fc", package = "hyperlight-component-util" }
-hyperlight-guest = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "2640a824b59d18e633e706e5639c7da30e7ad5fc", package = "hyperlight-guest" }
-hyperlight-guest-bin = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "2640a824b59d18e633e706e5639c7da30e7ad5fc", package = "hyperlight-guest-bin" }
-hyperlight-host = { git = "https://github.com/jsturtevant/hyperlight-1", rev = "2640a824b59d18e633e706e5639c7da30e7ad5fc", package = "hyperlight-host" }
+hyperlight-common = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "cfa020441d880d599cc516a050e6cf10236ca5c4" }
+hyperlight-component-macro = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "cfa020441d880d599cc516a050e6cf10236ca5c4" }
+hyperlight-component-util = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "cfa020441d880d599cc516a050e6cf10236ca5c4" }
+hyperlight-guest = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "cfa020441d880d599cc516a050e6cf10236ca5c4" }
+hyperlight-guest-bin = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "cfa020441d880d599cc516a050e6cf10236ca5c4" }
+hyperlight-host = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "cfa020441d880d599cc516a050e6cf10236ca5c4" }

--- a/src/javascript_sandbox/Cargo.toml
+++ b/src/javascript_sandbox/Cargo.toml
@@ -10,7 +10,7 @@ description = "Hyperlight JS guest for hyperlight-sandbox"
 hyperlight-sandbox.workspace = true
 anyhow = "1"
 url = "2"
-hyperlight-js = { git = "https://github.com/hyperlight-dev/hyperlight-js.git", rev = "915608fbc30e922c7ed03aa08b05c3a3a5614f39" }
+hyperlight-js = { git = "https://github.com/hyperlight-dev/hyperlight-js.git", rev = "b96774e7e19ce1945775498cd83d305a915e28df" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/src/wasm_sandbox/Justfile
+++ b/src/wasm_sandbox/Justfile
@@ -13,14 +13,14 @@ ensure-tools:
     # even if the cached binary was compiled with different dependency versions
     # (e.g. a stale wasmtime patch from the CI Cargo bin cache).
     cargo install hyperlight-wasm-aot --locked --force \
-        --git https://github.com/jsturtevant/hyperlight-wasm \
-        --rev 447c5893fc916f1e9faf9aaac59afc45e6591d1f
+        --git https://github.com/hyperlight-dev/hyperlight-wasm \
+        --rev 9292704a41316899d9d9c58e080a60ad331ab28d
 
 [windows]
 ensure-tools:
     if (-not (Get-Command clang -ErrorAction SilentlyContinue)) { Write-Error 'clang not found — install with: winget install LLVM.LLVM'; exit 1 }; \
     if (-not (Get-Command wasm-tools -ErrorAction SilentlyContinue)) { cargo install wasm-tools --locked }; \
-    cargo install hyperlight-wasm-aot --locked --force --git https://github.com/jsturtevant/hyperlight-wasm --rev 447c5893fc916f1e9faf9aaac59afc45e6591d1f
+    cargo install hyperlight-wasm-aot --locked --force --git https://github.com/hyperlight-dev/hyperlight-wasm --rev 9292704a41316899d9d9c58e080a60ad331ab28d
 
 guest-build-wasm: ensure-tools
     cd {{repo-root}}/src/wasm_sandbox/guests/python && uv run componentize-py \

--- a/src/wasm_sandbox/Justfile
+++ b/src/wasm_sandbox/Justfile
@@ -14,13 +14,13 @@ ensure-tools:
     # (e.g. a stale wasmtime patch from the CI Cargo bin cache).
     cargo install hyperlight-wasm-aot --locked --force \
         --git https://github.com/hyperlight-dev/hyperlight-wasm \
-        --rev f2ee1fe662adbba313cf3155b460d8fdb36b0793
+        --rev 2757fb9ff3e117c1513c325b3b32d3abd9918e9d
 
 [windows]
 ensure-tools:
     if (-not (Get-Command clang -ErrorAction SilentlyContinue)) { Write-Error 'clang not found — install with: winget install LLVM.LLVM'; exit 1 }; \
     if (-not (Get-Command wasm-tools -ErrorAction SilentlyContinue)) { cargo install wasm-tools --locked }; \
-    cargo install hyperlight-wasm-aot --locked --force --git https://github.com/hyperlight-dev/hyperlight-wasm --rev f2ee1fe662adbba313cf3155b460d8fdb36b0793
+    cargo install hyperlight-wasm-aot --locked --force --git https://github.com/hyperlight-dev/hyperlight-wasm --rev 2757fb9ff3e117c1513c325b3b32d3abd9918e9d
 
 guest-build-wasm: ensure-tools
     cd {{repo-root}}/src/wasm_sandbox/guests/python && uv run componentize-py \

--- a/src/wasm_sandbox/Justfile
+++ b/src/wasm_sandbox/Justfile
@@ -14,13 +14,13 @@ ensure-tools:
     # (e.g. a stale wasmtime patch from the CI Cargo bin cache).
     cargo install hyperlight-wasm-aot --locked --force \
         --git https://github.com/hyperlight-dev/hyperlight-wasm \
-        --rev 9292704a41316899d9d9c58e080a60ad331ab28d
+        --rev f2ee1fe662adbba313cf3155b460d8fdb36b0793
 
 [windows]
 ensure-tools:
     if (-not (Get-Command clang -ErrorAction SilentlyContinue)) { Write-Error 'clang not found — install with: winget install LLVM.LLVM'; exit 1 }; \
     if (-not (Get-Command wasm-tools -ErrorAction SilentlyContinue)) { cargo install wasm-tools --locked }; \
-    cargo install hyperlight-wasm-aot --locked --force --git https://github.com/hyperlight-dev/hyperlight-wasm --rev 9292704a41316899d9d9c58e080a60ad331ab28d
+    cargo install hyperlight-wasm-aot --locked --force --git https://github.com/hyperlight-dev/hyperlight-wasm --rev f2ee1fe662adbba313cf3155b460d8fdb36b0793
 
 guest-build-wasm: ensure-tools
     cd {{repo-root}}/src/wasm_sandbox/guests/python && uv run componentize-py \

--- a/src/wasm_sandbox/src/lib.rs
+++ b/src/wasm_sandbox/src/lib.rs
@@ -16,6 +16,8 @@ use hyperlight_wasm::{
 
 mod wasi_impl;
 
+type HostBindings = hyperlight_common::component::Negative;
+
 pub(crate) mod bindings {
     hyperlight_component_macro::host_bindgen!("wit/sandbox-world.wasm");
 }
@@ -44,7 +46,7 @@ pub struct HostState {
 }
 
 #[allow(refining_impl_trait)]
-impl bindings::root::component::RootImports for HostState {
+impl bindings::root::component::RootImports<HostBindings> for HostState {
     type Tools = HostState;
     fn tools(&mut self) -> &mut Self {
         self
@@ -196,7 +198,7 @@ impl bindings::root::component::RootImports for HostState {
     }
 }
 
-impl bindings::hyperlight::sandbox::Tools for HostState {
+impl bindings::hyperlight::sandbox::Tools<HostBindings> for HostState {
     fn dispatch(&mut self, name: String, args_json: String) -> Result<String, String> {
         let args: serde_json::Value = match serde_json::from_str(&args_json) {
             Ok(args) => args,
@@ -249,7 +251,7 @@ impl WasmComponentSandbox {
             .build()
             .context("failed to build ProtoWasmSandbox")?;
 
-        let rt = bindings::register_host_functions(&mut proto, state);
+        let rt = bindings::register_host_functions(&mut proto, state)?;
 
         let wasm_sandbox = proto
             .load_runtime()
@@ -266,7 +268,7 @@ impl WasmComponentSandbox {
     }
 
     fn run_impl(&mut self, code: &str) -> Result<ExecutionResult> {
-        use bindings::hyperlight::sandbox::ExecutorExports;
+        use bindings::hyperlight::sandbox::Executor;
 
         self.fs
             .lock()

--- a/src/wasm_sandbox/src/wasi_impl/cli.rs
+++ b/src/wasm_sandbox/src/wasi_impl/cli.rs
@@ -12,7 +12,7 @@ type HlResult<T> = T;
 // CLI: Environment, Exit, Stdin/Stdout/Stderr
 // ---------------------------------------------------------------------------
 
-impl wasi::cli::Environment for HostState {
+impl wasi::cli::Environment<crate::HostBindings> for HostState {
     fn get_environment(&mut self) -> HlResult<Vec<(String, String)>> {
         Vec::new()
     }
@@ -24,23 +24,23 @@ impl wasi::cli::Environment for HostState {
     }
 }
 
-impl wasi::cli::Exit for HostState {
+impl wasi::cli::Exit<crate::HostBindings> for HostState {
     fn exit(&mut self, _status: Result<(), ()>) -> HlResult<()> {}
 }
 
-impl wasi::cli::Stdin<Resource<Stream>> for HostState {
+impl wasi::cli::Stdin<crate::HostBindings, Resource<Stream>> for HostState {
     fn get_stdin(&mut self) -> HlResult<Resource<Stream>> {
         Resource::new(Stream::new())
     }
 }
 
-impl wasi::cli::Stdout<Resource<Stream>> for HostState {
+impl wasi::cli::Stdout<crate::HostBindings, Resource<Stream>> for HostState {
     fn get_stdout(&mut self) -> HlResult<Resource<Stream>> {
         Resource::new(Stream::new())
     }
 }
 
-impl wasi::cli::Stderr<Resource<Stream>> for HostState {
+impl wasi::cli::Stderr<crate::HostBindings, Resource<Stream>> for HostState {
     fn get_stderr(&mut self) -> HlResult<Resource<Stream>> {
         Resource::new(Stream::new())
     }
@@ -50,29 +50,29 @@ impl wasi::cli::Stderr<Resource<Stream>> for HostState {
 // CLI: Terminals (stubs — no terminal support)
 // ---------------------------------------------------------------------------
 
-impl wasi::cli::terminal_input::TerminalInput for HostState {
+impl wasi::cli::terminal_input::TerminalInput<crate::HostBindings> for HostState {
     type T = u32;
 }
-impl wasi::cli::TerminalInput for HostState {}
+impl wasi::cli::TerminalInput<crate::HostBindings> for HostState {}
 
-impl wasi::cli::terminal_output::TerminalOutput for HostState {
+impl wasi::cli::terminal_output::TerminalOutput<crate::HostBindings> for HostState {
     type T = u32;
 }
-impl wasi::cli::TerminalOutput for HostState {}
+impl wasi::cli::TerminalOutput<crate::HostBindings> for HostState {}
 
-impl wasi::cli::TerminalStdin<u32> for HostState {
+impl wasi::cli::TerminalStdin<crate::HostBindings, u32> for HostState {
     fn get_terminal_stdin(&mut self) -> HlResult<Option<u32>> {
         None
     }
 }
 
-impl wasi::cli::TerminalStdout<u32> for HostState {
+impl wasi::cli::TerminalStdout<crate::HostBindings, u32> for HostState {
     fn get_terminal_stdout(&mut self) -> HlResult<Option<u32>> {
         None
     }
 }
 
-impl wasi::cli::TerminalStderr<u32> for HostState {
+impl wasi::cli::TerminalStderr<crate::HostBindings, u32> for HostState {
     fn get_terminal_stderr(&mut self) -> HlResult<Option<u32>> {
         None
     }

--- a/src/wasm_sandbox/src/wasi_impl/clocks.rs
+++ b/src/wasm_sandbox/src/wasi_impl/clocks.rs
@@ -19,7 +19,7 @@ fn now() -> u64 {
     std::time::Instant::now().duration_since(*EPOCH).as_nanos() as u64
 }
 
-impl wasi::clocks::MonotonicClock<Resource<AnyPollable>> for HostState {
+impl wasi::clocks::MonotonicClock<crate::HostBindings, Resource<AnyPollable>> for HostState {
     fn now(&mut self) -> HlResult<monotonic_clock::Instant> {
         now()
     }
@@ -44,7 +44,7 @@ impl wasi::clocks::MonotonicClock<Resource<AnyPollable>> for HostState {
     }
 }
 
-impl wasi::clocks::WallClock for HostState {
+impl wasi::clocks::WallClock<crate::HostBindings> for HostState {
     fn now(&mut self) -> HlResult<wall_clock::Datetime> {
         let d = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)

--- a/src/wasm_sandbox/src/wasi_impl/filesystem.rs
+++ b/src/wasm_sandbox/src/wasi_impl/filesystem.rs
@@ -29,7 +29,7 @@ impl From<FsError> for fs_types::ErrorCode {
 // DirectoryEntryStream
 // ---------------------------------------------------------------------------
 
-impl fs_types::DirectoryEntryStream for HostState {
+impl fs_types::DirectoryEntryStream<crate::HostBindings> for HostState {
     type T = u32;
     fn read_directory_entry(
         &mut self,
@@ -64,8 +64,14 @@ impl fs_types::DirectoryEntryStream for HostState {
 // Descriptor
 // ---------------------------------------------------------------------------
 
-impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<Stream>>
-    for HostState
+impl
+    fs_types::Descriptor<
+        crate::HostBindings,
+        wall_clock::Datetime,
+        u32,
+        Resource<Stream>,
+        Resource<Stream>,
+    > for HostState
 {
     type T = u32;
 
@@ -380,8 +386,13 @@ impl fs_types::Descriptor<wall_clock::Datetime, u32, Resource<Stream>, Resource<
 }
 
 impl
-    wasi::filesystem::Types<wall_clock::Datetime, anyhow::Error, Resource<Stream>, Resource<Stream>>
-    for HostState
+    wasi::filesystem::Types<
+        crate::HostBindings,
+        wall_clock::Datetime,
+        anyhow::Error,
+        Resource<Stream>,
+        Resource<Stream>,
+    > for HostState
 {
     fn filesystem_error_code(
         &mut self,
@@ -391,7 +402,7 @@ impl
     }
 }
 
-impl wasi::filesystem::Preopens<u32> for HostState {
+impl wasi::filesystem::Preopens<crate::HostBindings, u32> for HostState {
     fn get_directories(&mut self) -> HlResult<Vec<(u32, String)>> {
         let Ok(fs) = self.fs.lock() else {
             return Vec::new();

--- a/src/wasm_sandbox/src/wasi_impl/http.rs
+++ b/src/wasm_sandbox/src/wasi_impl/http.rs
@@ -38,7 +38,7 @@ impl From<HeaderError> for http_types::HeaderError {
     }
 }
 
-impl http_types::Fields for HostState {
+impl http_types::Fields<crate::HostBindings> for HostState {
     type T = Resource<Headers>;
 
     fn new(&mut self) -> Resource<Headers> {
@@ -115,7 +115,9 @@ impl http_types::Fields for HostState {
 // IncomingRequest
 // ---------------------------------------------------------------------------
 
-impl http_types::IncomingRequest<Resource<Headers>, Resource<IncomingBody>> for HostState {
+impl http_types::IncomingRequest<crate::HostBindings, Resource<Headers>, Resource<IncomingBody>>
+    for HostState
+{
     type T = Resource<IncomingRequest>;
     fn method(
         &mut self,
@@ -164,7 +166,9 @@ impl http_types::IncomingRequest<Resource<Headers>, Resource<IncomingBody>> for 
 // OutgoingRequest
 // ---------------------------------------------------------------------------
 
-impl http_types::OutgoingRequest<Resource<Headers>, Resource<OutgoingBody>> for HostState {
+impl http_types::OutgoingRequest<crate::HostBindings, Resource<Headers>, Resource<OutgoingBody>>
+    for HostState
+{
     type T = Resource<OutgoingRequest>;
     fn new(&mut self, headers: Resource<Headers>) -> Resource<OutgoingRequest> {
         Resource::new(OutgoingRequest::new(headers))
@@ -248,7 +252,7 @@ fn as_u64_nanos_saturating(duration: &std::time::Duration) -> u64 {
     duration.as_nanos().min(u64::MAX as u128) as u64
 }
 
-impl http_types::RequestOptions<u64> for HostState {
+impl http_types::RequestOptions<crate::HostBindings, u64> for HostState {
     type T = Resource<RequestOptions>;
     fn new(&mut self) -> Resource<RequestOptions> {
         Resource::default()
@@ -317,7 +321,7 @@ impl http_types::RequestOptions<u64> for HostState {
 // ResponseOutparam
 // ---------------------------------------------------------------------------
 
-impl http_types::ResponseOutparam<Resource<OutgoingResponse>> for HostState {
+impl http_types::ResponseOutparam<crate::HostBindings, Resource<OutgoingResponse>> for HostState {
     type T = Resource<ResponseOutparam>;
     fn set(
         &mut self,
@@ -332,7 +336,9 @@ impl http_types::ResponseOutparam<Resource<OutgoingResponse>> for HostState {
 // IncomingResponse
 // ---------------------------------------------------------------------------
 
-impl http_types::IncomingResponse<Resource<Headers>, Resource<IncomingBody>> for HostState {
+impl http_types::IncomingResponse<crate::HostBindings, Resource<Headers>, Resource<IncomingBody>>
+    for HostState
+{
     type T = Resource<IncomingResponse>;
     fn status(
         &mut self,
@@ -363,7 +369,9 @@ impl http_types::IncomingResponse<Resource<Headers>, Resource<IncomingBody>> for
 // IncomingBody
 // ---------------------------------------------------------------------------
 
-impl http_types::IncomingBody<Resource<FutureHeaders>, Resource<Stream>> for HostState {
+impl http_types::IncomingBody<crate::HostBindings, Resource<FutureHeaders>, Resource<Stream>>
+    for HostState
+{
     type T = Resource<IncomingBody>;
     fn stream(
         &mut self,
@@ -385,7 +393,9 @@ impl http_types::IncomingBody<Resource<FutureHeaders>, Resource<Stream>> for Hos
 // OutgoingBody
 // ---------------------------------------------------------------------------
 
-impl http_types::OutgoingBody<Resource<Headers>, Resource<Stream>> for HostState {
+impl http_types::OutgoingBody<crate::HostBindings, Resource<Headers>, Resource<Stream>>
+    for HostState
+{
     type T = Resource<OutgoingBody>;
     fn write(
         &mut self,
@@ -415,7 +425,9 @@ impl http_types::OutgoingBody<Resource<Headers>, Resource<Stream>> for HostState
 // OutgoingResponse
 // ---------------------------------------------------------------------------
 
-impl http_types::OutgoingResponse<Resource<Headers>, Resource<OutgoingBody>> for HostState {
+impl http_types::OutgoingResponse<crate::HostBindings, Resource<Headers>, Resource<OutgoingBody>>
+    for HostState
+{
     type T = Resource<OutgoingResponse>;
     fn new(&mut self, headers: Resource<Headers>) -> Resource<OutgoingResponse> {
         Resource::new(OutgoingResponse::new(headers))
@@ -453,7 +465,9 @@ impl http_types::OutgoingResponse<Resource<Headers>, Resource<OutgoingBody>> for
 // FutureTrailers
 // ---------------------------------------------------------------------------
 
-impl http_types::FutureTrailers<Resource<Headers>, Resource<AnyPollable>> for HostState {
+impl http_types::FutureTrailers<crate::HostBindings, Resource<Headers>, Resource<AnyPollable>>
+    for HostState
+{
     type T = Resource<FutureHeaders>;
     fn subscribe(
         &mut self,
@@ -480,8 +494,12 @@ impl http_types::FutureTrailers<Resource<Headers>, Resource<AnyPollable>> for Ho
 // FutureIncomingResponse
 // ---------------------------------------------------------------------------
 
-impl http_types::FutureIncomingResponse<Resource<IncomingResponse>, Resource<AnyPollable>>
-    for HostState
+impl
+    http_types::FutureIncomingResponse<
+        crate::HostBindings,
+        Resource<IncomingResponse>,
+        Resource<AnyPollable>,
+    > for HostState
 {
     type T = Resource<FutureIncomingResponse>;
     fn subscribe(
@@ -504,8 +522,14 @@ impl http_types::FutureIncomingResponse<Resource<IncomingResponse>, Resource<Any
 // ---------------------------------------------------------------------------
 
 impl
-    wasi::http::Types<u64, anyhow::Error, Resource<Stream>, Resource<Stream>, Resource<AnyPollable>>
-    for HostState
+    wasi::http::Types<
+        crate::HostBindings,
+        u64,
+        anyhow::Error,
+        Resource<Stream>,
+        Resource<Stream>,
+        Resource<AnyPollable>,
+    > for HostState
 {
     fn http_error_code(
         &mut self,

--- a/src/wasm_sandbox/src/wasi_impl/http_handler.rs
+++ b/src/wasm_sandbox/src/wasi_impl/http_handler.rs
@@ -41,6 +41,7 @@ fn wasi_method_to_http_method(
 
 impl
     wasi::http::OutgoingHandler<
+        crate::HostBindings,
         ErrorCode,
         Resource<FutureIncomingResponse>,
         Resource<OutgoingRequest>,

--- a/src/wasm_sandbox/src/wasi_impl/io.rs
+++ b/src/wasm_sandbox/src/wasi_impl/io.rs
@@ -20,20 +20,20 @@ const MAX_ALLOC_BYTES: u64 = 16 * 1024 * 1024;
 // IO: Error
 // ---------------------------------------------------------------------------
 
-impl wasi::io::error::Error for HostState {
+impl wasi::io::error::Error<crate::HostBindings> for HostState {
     type T = anyhow::Error;
     fn to_debug_string(&mut self, self_: BorrowedResourceGuard<anyhow::Error>) -> HlResult<String> {
         self_.to_string()
     }
 }
 
-impl wasi::io::Error for HostState {}
+impl wasi::io::Error<crate::HostBindings> for HostState {}
 
 // ---------------------------------------------------------------------------
 // IO: Poll
 // ---------------------------------------------------------------------------
 
-impl wasi::io::poll::Pollable for HostState {
+impl wasi::io::poll::Pollable<crate::HostBindings> for HostState {
     type T = Resource<AnyPollable>;
     fn ready(&mut self, self_: BorrowedResourceGuard<Resource<AnyPollable>>) -> HlResult<bool> {
         self_.write().block_on().ready().block_on()
@@ -43,7 +43,7 @@ impl wasi::io::poll::Pollable for HostState {
     }
 }
 
-impl wasi::io::Poll for HostState {
+impl wasi::io::Poll<crate::HostBindings> for HostState {
     fn poll(
         &mut self,
         pollables: Vec<BorrowedResourceGuard<Resource<AnyPollable>>>,
@@ -72,7 +72,7 @@ impl wasi::io::Poll for HostState {
 // IO: Streams
 // ---------------------------------------------------------------------------
 
-impl streams::InputStream<anyhow::Error, Resource<AnyPollable>> for HostState {
+impl streams::InputStream<crate::HostBindings, anyhow::Error, Resource<AnyPollable>> for HostState {
     type T = Resource<Stream>;
     fn read(
         &mut self,
@@ -124,7 +124,14 @@ impl streams::InputStream<anyhow::Error, Resource<AnyPollable>> for HostState {
     }
 }
 
-impl streams::OutputStream<anyhow::Error, Resource<Stream>, Resource<AnyPollable>> for HostState {
+impl
+    streams::OutputStream<
+        crate::HostBindings,
+        anyhow::Error,
+        Resource<Stream>,
+        Resource<AnyPollable>,
+    > for HostState
+{
     type T = Resource<Stream>;
     fn check_write(
         &mut self,
@@ -233,4 +240,4 @@ impl streams::OutputStream<anyhow::Error, Resource<Stream>, Resource<AnyPollable
     }
 }
 
-impl wasi::io::Streams<anyhow::Error, Resource<AnyPollable>> for HostState {}
+impl wasi::io::Streams<crate::HostBindings, anyhow::Error, Resource<AnyPollable>> for HostState {}

--- a/src/wasm_sandbox/src/wasi_impl/random.rs
+++ b/src/wasm_sandbox/src/wasi_impl/random.rs
@@ -21,7 +21,7 @@ fn random_u64() -> u64 {
     })
 }
 
-impl wasi::random::Random for HostState {
+impl wasi::random::Random<crate::HostBindings> for HostState {
     fn get_random_bytes(&mut self, len: u64) -> HlResult<Vec<u8>> {
         let capped = len.min(MAX_ALLOC_BYTES) as usize;
         let mut buf = vec![0u8; capped];
@@ -33,7 +33,7 @@ impl wasi::random::Random for HostState {
     }
 }
 
-impl wasi::random::Insecure for HostState {
+impl wasi::random::Insecure<crate::HostBindings> for HostState {
     fn get_insecure_random_bytes(&mut self, len: u64) -> HlResult<Vec<u8>> {
         let capped = len.min(MAX_ALLOC_BYTES) as usize;
         let mut buf = vec![0u8; capped];
@@ -45,7 +45,7 @@ impl wasi::random::Insecure for HostState {
     }
 }
 
-impl wasi::random::InsecureSeed for HostState {
+impl wasi::random::InsecureSeed<crate::HostBindings> for HostState {
     fn insecure_seed(&mut self) -> HlResult<(u64, u64)> {
         (random_u64(), random_u64())
     }

--- a/src/wasm_sandbox/src/wasi_impl/sockets.rs
+++ b/src/wasm_sandbox/src/wasi_impl/sockets.rs
@@ -17,13 +17,13 @@ type HlResult<T> = T;
 // Sockets: Network
 // ---------------------------------------------------------------------------
 
-impl network::Network for HostState {
+impl network::Network<crate::HostBindings> for HostState {
     type T = u32;
 }
 
-impl wasi::sockets::Network for HostState {}
+impl wasi::sockets::Network<crate::HostBindings> for HostState {}
 
-impl wasi::sockets::InstanceNetwork<u32> for HostState {
+impl wasi::sockets::InstanceNetwork<crate::HostBindings, u32> for HostState {
     fn instance_network(&mut self) -> HlResult<u32> {
         0
     }
@@ -35,6 +35,7 @@ impl wasi::sockets::InstanceNetwork<u32> for HostState {
 
 impl
     tcp::TcpSocket<
+        crate::HostBindings,
         monotonic_clock::Duration,
         network::ErrorCode,
         Resource<Stream>,
@@ -225,6 +226,7 @@ impl
 
 impl
     wasi::sockets::Tcp<
+        crate::HostBindings,
         monotonic_clock::Duration,
         network::ErrorCode,
         Resource<Stream>,
@@ -237,8 +239,13 @@ impl
 {
 }
 
-impl wasi::sockets::TcpCreateSocket<network::ErrorCode, network::IpAddressFamily, u32>
-    for HostState
+impl
+    wasi::sockets::TcpCreateSocket<
+        crate::HostBindings,
+        network::ErrorCode,
+        network::IpAddressFamily,
+        u32,
+    > for HostState
 {
     fn create_tcp_socket(
         &mut self,
@@ -253,8 +260,12 @@ impl wasi::sockets::TcpCreateSocket<network::ErrorCode, network::IpAddressFamily
 // ---------------------------------------------------------------------------
 
 impl
-    udp::IncomingDatagramStream<network::ErrorCode, network::IpSocketAddress, Resource<AnyPollable>>
-    for HostState
+    udp::IncomingDatagramStream<
+        crate::HostBindings,
+        network::ErrorCode,
+        network::IpSocketAddress,
+        Resource<AnyPollable>,
+    > for HostState
 {
     type T = u32;
     fn receive(
@@ -271,8 +282,12 @@ impl
 }
 
 impl
-    udp::OutgoingDatagramStream<network::ErrorCode, network::IpSocketAddress, Resource<AnyPollable>>
-    for HostState
+    udp::OutgoingDatagramStream<
+        crate::HostBindings,
+        network::ErrorCode,
+        network::IpSocketAddress,
+        Resource<AnyPollable>,
+    > for HostState
 {
     type T = u32;
     fn check_send(
@@ -295,6 +310,7 @@ impl
 
 impl
     udp::UdpSocket<
+        crate::HostBindings,
         network::ErrorCode,
         u32,
         network::IpAddressFamily,
@@ -390,6 +406,7 @@ impl
 
 impl
     wasi::sockets::Udp<
+        crate::HostBindings,
         network::ErrorCode,
         network::IpAddressFamily,
         network::IpSocketAddress,
@@ -399,8 +416,13 @@ impl
 {
 }
 
-impl wasi::sockets::UdpCreateSocket<network::ErrorCode, network::IpAddressFamily, u32>
-    for HostState
+impl
+    wasi::sockets::UdpCreateSocket<
+        crate::HostBindings,
+        network::ErrorCode,
+        network::IpAddressFamily,
+        u32,
+    > for HostState
 {
     fn create_udp_socket(
         &mut self,
@@ -416,6 +438,7 @@ impl wasi::sockets::UdpCreateSocket<network::ErrorCode, network::IpAddressFamily
 
 impl
     ip_name_lookup::ResolveAddressStream<
+        crate::HostBindings,
         network::ErrorCode,
         network::IpAddress,
         Resource<AnyPollable>,
@@ -433,8 +456,14 @@ impl
     }
 }
 
-impl wasi::sockets::IpNameLookup<network::ErrorCode, network::IpAddress, u32, Resource<AnyPollable>>
-    for HostState
+impl
+    wasi::sockets::IpNameLookup<
+        crate::HostBindings,
+        network::ErrorCode,
+        network::IpAddress,
+        u32,
+        Resource<AnyPollable>,
+    > for HostState
 {
     fn resolve_addresses(
         &mut self,


### PR DESCRIPTION
The component binding changes previously required forked Hyperlight repositories. Those changes are now available upstream, and hyperlight-wasm PR #520 provides the corresponding Wasm integration.

## Summary

- pin Hyperlight to upstream revision `cfa0204`
- pin hyperlight-wasm to main
- update Hyperlight JS to a Hyperlight 0.16-compatible revision
- adapt host bindings to the new positivity generic and fallible registration API
- raise the workspace MSRV to Rust 1.94 to match hyperlight-wasm
