### PR TITLE
Bump hyperlight sandbox to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-javascript-sandbox"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "hyperlight-js",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-sandbox"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-sandbox-backend-hyperlight-js"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "hyperlight-javascript-sandbox",
  "hyperlight-sandbox",
@@ -2006,7 +2006,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-sandbox-backend-wasm"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "hyperlight-sandbox",
  "hyperlight-sandbox-pyo3-common",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-sandbox-dotnet-ffi"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "hyperlight-javascript-sandbox",
@@ -2031,7 +2031,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-sandbox-pyo3-common"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "hyperlight-sandbox",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-wasm-sandbox"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.94"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hyperlight-sandbox-dev"
-version = "0.5.0"
+version = "0.6.0"
 requires-python = ">=3.10"
 
 [tool.uv]

--- a/src/sdk/dotnet/Directory.Build.props
+++ b/src/sdk/dotnet/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.5.0</Version>
+    <Version>0.6.0</Version>
     <Authors>Hyperlight developers</Authors>
     <Company>hyperlight-dev</Company>
     <Copyright>Copyright © Microsoft 2026</Copyright>

--- a/src/sdk/python/core/pyproject.toml
+++ b/src/sdk/python/core/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hyperlight-sandbox"
-version = "0.5.0"
+version = "0.6.0"
 description = "Python API for running code in isolated Hyperlight sandboxes with swappable backends"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = []
-optional-dependencies = { wasm = ["hyperlight-sandbox-backend-wasm>=0.5.0"], hyperlight_js = ["hyperlight-sandbox-backend-hyperlight-js>=0.5.0"], python_guest = ["hyperlight-sandbox-python-guest>=0.5.0"], javascript_guest = ["hyperlight-sandbox-javascript-guest>=0.5.0"], dev = ["atheris>=2.3.0; python_version < '3.13'"] }
+optional-dependencies = { wasm = ["hyperlight-sandbox-backend-wasm>=0.6.0"], hyperlight_js = ["hyperlight-sandbox-backend-hyperlight-js>=0.6.0"], python_guest = ["hyperlight-sandbox-python-guest>=0.6.0"], javascript_guest = ["hyperlight-sandbox-javascript-guest>=0.6.0"], dev = ["atheris>=2.3.0; python_version < '3.13'"] }
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",

--- a/src/sdk/python/hyperlight_js_backend/pyproject.toml
+++ b/src/sdk/python/hyperlight_js_backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "hyperlight-sandbox-backend-hyperlight-js"
-version = "0.5.0"
+version = "0.6.0"
 description = "HyperlightJS backend implementation for hyperlight-sandbox"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sdk/python/wasm_backend/pyproject.toml
+++ b/src/sdk/python/wasm_backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "hyperlight-sandbox-backend-wasm"
-version = "0.5.0"
+version = "0.6.0"
 description = "Wasm backend implementation for hyperlight-sandbox"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sdk/python/wasm_guests/javascript_guest/pyproject.toml
+++ b/src/sdk/python/wasm_guests/javascript_guest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hyperlight-sandbox-javascript-guest"
-version = "0.5.0"
+version = "0.6.0"
 description = "Packaged Hyperlight Wasm JavaScript guest exposed as javascript_guest.path"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sdk/python/wasm_guests/python_guest/pyproject.toml
+++ b/src/sdk/python/wasm_guests/python_guest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hyperlight-sandbox-python-guest"
-version = "0.5.0"
+version = "0.6.0"
 description = "Packaged Hyperlight Wasm Python guest exposed as python_guest.path"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/wasm_sandbox/guests/javascript/package-lock.json
+++ b/src/wasm_sandbox/guests/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hyperlight-sandbox-js-guest",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hyperlight-sandbox-js-guest",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "devDependencies": {
         "@bytecodealliance/componentize-js": "^0.22.0",
         "@bytecodealliance/jco": "^1.29.0"

--- a/src/wasm_sandbox/guests/javascript/package.json
+++ b/src/wasm_sandbox/guests/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperlight-sandbox-js-guest",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/uv.lock
+++ b/uv.lock
@@ -533,7 +533,7 @@ wheels = [
 
 [[package]]
 name = "hyperlight-sandbox"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "src/sdk/python/core" }
 
 [package.optional-dependencies]
@@ -565,17 +565,17 @@ provides-extras = ["wasm", "hyperlight-js", "python-guest", "javascript-guest", 
 
 [[package]]
 name = "hyperlight-sandbox-backend-hyperlight-js"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "src/sdk/python/hyperlight_js_backend" }
 
 [[package]]
 name = "hyperlight-sandbox-backend-wasm"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "src/sdk/python/wasm_backend" }
 
 [[package]]
 name = "hyperlight-sandbox-dev"
-version = "0.5.0"
+version = "0.6.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]
@@ -639,12 +639,12 @@ dev = [
 
 [[package]]
 name = "hyperlight-sandbox-javascript-guest"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "src/sdk/python/wasm_guests/javascript_guest" }
 
 [[package]]
 name = "hyperlight-sandbox-python-guest"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "src/sdk/python/wasm_guests/python_guest" }
 
 [[package]]


### PR DESCRIPTION
Bumps all Rust, Python, JavaScript, and .NET package manifests and generated lockfile metadata to 0.6.0 so the packages remain version-aligned for the next release.
